### PR TITLE
New tiddlers are public

### DIFF
--- a/src/backstage/Backstage.tid
+++ b/src/backstage/Backstage.tid
@@ -38,6 +38,8 @@ You can associate your account with multiple identities. If you have an open id 
 <<TiddlySpaceRegister>>
 
 !Options
+<<option chkNewTiddlersArePrivate>> New tiddlers default to private.
+
 <<search>><<closeAll>><<permaview>><<newTiddler>><<newJournal "DD MMM YYYY" "journal">><<saveChanges>><<slider chkSliderOptionsPanel OptionsPanel "options »" "Change TiddlyWiki advanced options">>
 
 !Password

--- a/src/plugins/TiddlySpaceConfig.js
+++ b/src/plugins/TiddlySpaceConfig.js
@@ -188,6 +188,11 @@ config.macros.backstageInit = {
 	}
 };
 
+if(config.options.chkNewTiddlersArePrivate) {
+	config.defaultCustomFields["server.workspace"] = "bags/%0_private".format([plugin.currentSpace.name]);
+} else {
+	config.defaultCustomFields["server.workspace"] = "bags/%0_public".format([plugin.currentSpace.name]);
+}
 // register style sheet for backstage separately (important)
 store.addNotification("StyleSheetBackstage", refreshStyles);
 

--- a/src/plugins/ToggleTiddlerPrivacyPlugin.js
+++ b/src/plugins/ToggleTiddlerPrivacyPlugin.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|ToggleTiddlerPrivacyPlugin|
-|''Version''|0.6.0|
+|''Version''|0.6.1|
 |''Status''|@@beta@@|
 |''Description''|Allows you to set the privacy of new tiddlers and external tiddlers within an EditTemplate|
 |''Requires''|TiddlySpaceConfig|
@@ -22,7 +22,9 @@ Allows you to set the default privacy value (Default is private)
 var tiddlyspace = config.extensions.tiddlyspace;
 
 var macro = config.macros.setPrivacy = {
-	DEFAULT_STATE: "private",
+	getSpaceSetting: function() {
+		return config.options.chkNewTiddlersArePrivate ? "private" : "public"
+	},
 
 	handler: function(place, macroName, params, wikifier, paramString, tiddler) {
 		if(readOnly) {
@@ -93,7 +95,7 @@ var macro = config.macros.setPrivacy = {
 		$("<label />").text("private").appendTo(container); // TODO: i18n
 		var rPublic = rbtn.clone().val("public").addClass("isPublic").appendTo(container);
 		$("<label />").text("public").appendTo(container); // TODO: i18n
-		var status = macro.DEFAULT_STATE;
+		var status = macro.getSpaceSetting();
 		var el = story.findContainingTiddler(container);
 		$("[type=radio]", container).click(function(ev) {
 			var btn = $(ev.target);
@@ -107,7 +109,7 @@ var macro = config.macros.setPrivacy = {
 			}
 		});
 		if(!defaultValue) {
-			defaultValue = macro.DEFAULT_STATE == "public" ? publicBag : privateBag;
+			defaultValue = macro.getSpaceSetting() == "public" ? publicBag : privateBag;
 		}
 		// TODO: replace with a hijack of displayTiddler?
 		window.setTimeout(function() {


### PR DESCRIPTION
If we decide we want it..
This updates the private/public setting on a _user_ level. It does not deal yet with the _space_ level.

ie. If I tick the checkbox option make new tiddlers private, and cdent is also a member of my space, he must also click it if he wants to create private tiddlers otherwise public tiddlers will be created.

I think we need some way of storing settings for spaces (maybe part of TiddlyInit?)
