### PR TITLE
Open id registration

### DIFF
--- a/src/plugins/TiddlySpaceUserControls.js
+++ b/src/plugins/TiddlySpaceUserControls.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceUserControls|
-|''Version''|0.5.5|
+|''Version''|0.5.6|
 |''Description''|registration and login UIs|
 |''Status''|@@beta@@|
 |''Source''|http://github.com/TiddlySpace/tiddlyspace/raw/master/src/plugins/TiddlySpaceUserControls.js|
@@ -143,6 +143,7 @@ var tsl = config.macros.TiddlySpaceLogin = {
 			data: {
 				user: username,
 				password: password,
+				csrf_token: tiddlyspace.getCSRFToken(),
 				tiddlyweb_redirect: tweb.serverPrefix + "/status" // workaround to marginalize automatic subsequent GET
 			},
 			success: callback,

--- a/tiddlywebplugins/tiddlyspace/__init__.py
+++ b/tiddlywebplugins/tiddlyspace/__init__.py
@@ -169,6 +169,8 @@ def _status_gather_data(environ):
         store.get(User(usersign))
     except NoUserError:
         data['username'] = 'GUEST'
+        if usersign != 'GUEST':
+          data['identity'] = usersign
     return data
 
 


### PR DESCRIPTION
Some slight modifications to TiddlySpace to provide a path for allowing login without a password with openids:

User logs in via non-cookie based login (eg. openid)
The server sets tiddlyweb_user and tiddlyweb_secondary_user cookies. These are both set on the domain *.tiddlyspace.com
Status returns the users identity in an identity entry.
A form is provided asking the user for a username / space name.
User inputs name.
If that name is available then a TiddlyWeb User object is created for name. A randomly generated password is added.
You are then logged in as name using that username and password.
You are redirected to <username>.tiddlyspace.com#auth:OpenID=<identity>
Since the tiddlyweb_secondary_user cookie is still set this successfully associates name with your openid
Next time you login everything just works
