### PR TITLE
Kml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         'tiddlywebplugins.privateer',
         'tiddlywebplugins.lazy',
         'tiddlywebplugins.relativetime',
-        'tiddlywebplugins.jsonp>=0.4'
+        'tiddlywebplugins.jsonp>=0.4',
+        'tiddlywebplugins.kml>=0.2.1'
     ],
     include_package_data = True,
     zip_safe = False

--- a/tiddlywebplugins/tiddlyspace/__init__.py
+++ b/tiddlywebplugins/tiddlyspace/__init__.py
@@ -56,6 +56,7 @@ def init(config):
     import tiddlywebplugins.privateer
     import tiddlywebplugins.relativetime
     import tiddlywebplugins.jsonp
+    import tiddlywebplugins.kml
 
     @make_command()
     def addmember(args):
@@ -113,6 +114,7 @@ def init(config):
     tiddlywebplugins.lazy.init(config)
     tiddlywebplugins.privateer.init(config)
     tiddlywebplugins.jsonp.init(config)
+    tiddlywebplugins.kml.init(config)
 
     # XXX: The following is required to work around issues with twp.instancer.
     # Without this, config settings from tiddlywebwiki take precedence.


### PR DESCRIPTION
Adds support for kml files

Required for Open Britain.

(note that tiddlers that do not have the required geo.lat/geo.long fields will simply not be present (i.e. they will not throw an error, or return 404 or whatever.))
