### PR TITLE
Privacy roundel

### DIFF
--- a/src/plugins/TiddlySpacePublishingCommands.js
+++ b/src/plugins/TiddlySpacePublishingCommands.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpacePublishingCommands|
-|''Version''|0.8.4|
+|''Version''|0.8.5|
 |''Status''|@@beta@@|
 |''Description''|toolbar commands for drafting and publishing|
 |''Author''|Jon Robson|
@@ -143,14 +143,13 @@ var cmd = config.commands.publishTiddler = {
 								callback(info);
 							}
 							store.setDirty(_dirty);
-							story.refreshTiddler(newTitle, null, true); // for drafts
 						});
 					} else {
 						if(callback) {
 							callback(info);
 						}
-						story.refreshTiddler(newTitle, null, true);
 					}
+					refreshDisplay();
 				}
 		});
 	}

--- a/src/test/fixtures/tiddlywiki.js
+++ b/src/test/fixtures/tiddlywiki.js
@@ -7,6 +7,7 @@ backstage = {};
 ajaxReq = NOP;
 refreshElements = NOP;
 refreshStyles = NOP;
+refreshDisplay = NOP;
 saveChanges = NOP;
 autoSaveChanges = NOP;
 saveSystemSetting = NOP;


### PR DESCRIPTION
Changes refreshTiddler to refreshDisplay so that use cases such as publishing from the sidebar (eg in the sidebar space) refresh the roundel properly
