### PR TITLE
Robots

### DIFF
--- a/src/system-info/index.recipe
+++ b/src/system-info/index.recipe
@@ -1,2 +1,3 @@
 tiddler: GettingStarted.tid
 tiddler: SiteIcon.tid
+tiddler: robots.tid

--- a/src/system-info/robots.tid
+++ b/src/system-info/robots.tid
@@ -1,0 +1,6 @@
+type: text/plain
+tags: excludeLists excludeSearch
+
+User-agent: *
+Disallow: /bags/*/tiddlers.wiki
+Disallow: /recipes/*/tiddlers.wiki

--- a/tiddlywebplugins/tiddlyspace/handler.py
+++ b/tiddlywebplugins/tiddlyspace/handler.py
@@ -29,14 +29,15 @@ def friendly_uri(environ, start_response):
     """
     http_host, host_url = determine_host(environ)
     if http_host == host_url:
-        raise HTTP404('No resource found')
+        space_name = "frontpage"
     else:
         space_name = determine_space(environ, http_host)
-        recipe_name = determine_space_recipe(environ, space_name)
-        # tiddler_name already in uri
-        environ['wsgiorg.routing_args'][1]['recipe_name'] = recipe_name.encode(
-            'UTF-8')
-        return get_tiddler(environ, start_response)
+
+    recipe_name = determine_space_recipe(environ, space_name)
+    # tiddler_name already in uri
+    environ['wsgiorg.routing_args'][1]['recipe_name'] = recipe_name.encode(
+        'UTF-8')
+    return get_tiddler(environ, start_response)
 
 
 @require_any_user()


### PR DESCRIPTION
This adds a robots.txt file to the system-info space meaning it gives all spaces a robots.txt file.

This is useful for a user to control how their space is indexed. The defaults suggest not indexing any other wikis other than the spaces you see at http://<space name>.tiddlyspace.com - this is useful as it prevents users accessing versions of your space that are broken or incomplete due to a user finding a link to say a bag on a search engine. It's also useful as some bags have hundreds/thousands of tiddlers (e.g. http://confusedofcalcutta.tiddlyspace.com/bags/confusedofcalcutta_public/tiddlers) as the user may be using lazy loading rather than loading up an entire wiki.

Since it is a tiddler a user can tweak these or remove it altogether depending on their preferences.

A slight change to the server was needed to make sure http://tiddlyspace.com/robots.txt worked (previously throwing a 404)
