### PR TITLE
Random color refactorings

### DIFF
--- a/src/system-plugins/index.recipe
+++ b/src/system-plugins/index.recipe
@@ -1,4 +1,4 @@
-tiddler: http://svn.tiddlywiki.org/Trunk/contributors/JonRobson/plugins/RandomColorPalettePlugin/plugins/RandomColorPalettePlugin.js
+tiddler: https://github.com/jdlrobson/TiddlyWikiPlugins/raw/master/plugins/RandomColorPalettePlugin/RandomColorPalettePlugin.js
 tiddler: http://svn.tiddlywiki.org/Trunk/contributors/PaulDowney/plugins/TiddlySpaceLinkPlugin/TiddlySpaceLinkPlugin.js
 tiddler: https://github.com/bengillies/tiddlyweb-client-plugins/raw/master/Importing/tiddlers/TiddlyFileImporter.js
 recipe: ../plugins/system-plugins.recipe


### PR DESCRIPTION
Moved RandomColorPalette plugin to github.
It has had several bits of refactoring for the purpose of some new plugins I have been working on that wanted to make use of its code.
See https://github.com/jdlrobson/TiddlyWikiPlugins if interested.
