### PR TITLE
enforce better defaults for origin macro

### DIFF
--- a/src/plugins/TiddlySpaceTiddlerIconsPlugin.js
+++ b/src/plugins/TiddlySpaceTiddlerIconsPlugin.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceTiddlerIconsPlugin|
-|''Version''|0.8.8|
+|''Version''|0.8.9|
 |''Status''|@@beta@@|
 |''Author''|Jon Robson|
 |''Description''|Provides ability to render SiteIcons and icons that correspond to the home location of given tiddlers|
@@ -137,6 +137,7 @@ var originMacro = config.macros.tiddlerOrigin = {
 		originMacro.renderIcon(tiddler, type, btn, options);
 	},
 	getOptions: function(paramString) {
+		paramString = "%0 label:no width:48 height:48 spaceLink:yes preserveAspectRatio:yes".format(paramString);
 		var parsedParams = paramString.parseParams("name");
 		var params = parsedParams[0].name;
 		var options = {


### PR DESCRIPTION
when using
    <<view field SiteIcon>>
    <<originMacro>>

currently the following parameters are commonly used:
label:no spaceLink:yes height:48 width:48 preserveAspectRatio:yes

It would be more useful to omit these parameters.
