### PR TITLE
specify format unified in diff url

### DIFF
--- a/src/plugins/ErrorHandler.js
+++ b/src/plugins/ErrorHandler.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|ErrorHandlerPlugin|
-|''Version''|0.4.2|
+|''Version''|0.4.3|
 |''Author''|Jon Robson|
 |''Description''|Localised tiddler save errors including edit conflict resolution.|
 |''CoreVersion''|2.6.1|
@@ -134,7 +134,7 @@ var plugin = config.extensions.errorHandler = {
 		ajaxReq({
 			type: "get",
 			dataType: "text",
-			url: "/diff?rev1=%0/%1/%2&rev2=%0/%1".format(workspace, title, latestRevision),
+			url: "/diff?format=unified&rev1=%0/%1/%2&rev2=%0/%1".format(workspace, title, latestRevision),
 			success: callback,
 			error: function() {
 				displayMessage(msgs.reviewDiffError);


### PR DESCRIPTION
When an edit conflict appears  the message:
"Review the changes that have been made whilst you were editing this tiddler. Fold relevant changes back into your version.
Red highlight shows content removed. Green highlight shows content added." is displayed.

However the diff associated is not correctly formatted. No green or red highlights are shown.
This is fixed by specifying
format=unified in the url in the ErrorHandlerPlugin
