### PR TITLE
fixed a bug in non-TidddlyWiki part of anti CSRF stuff

### DIFF
--- a/src/plugins/TiddlySpaceCSRF.js
+++ b/src/plugins/TiddlySpaceCSRF.js
@@ -13,7 +13,8 @@ var getCSRFToken = function(window) {
 	return csrf_token;
 };
 
-if (config && config.extensions && config.extensions.tiddlyspace &&
+if (typeof config !== 'undefined' && config.extensions &&
+		config.extensions.tiddlyspace &&
 		config.extensions.tiddlyspace.getCSRFToken === null) {
 	config.extensions.tiddlyspace.getCSRFToken = getCSRFToken;
 } else {


### PR DESCRIPTION
The anti CSRF javascript function was split into a separate file so that
it could be used both inside and outside TiddlyWiki. There was a bug in
the code though, meaning that it only worked inside TiddlyWiki.

This fixes that bug.
