### PR TITLE
escape stuff in templates

### DIFF
--- a/tiddlywebplugins/templates/bag.html
+++ b/tiddlywebplugins/templates/bag.html
@@ -3,7 +3,7 @@
         <div class="section" id="bag">
         <p><a href="/bags/{{ bag.name|uri }}/tiddlers">Tiddlers in
             this bag</a></p>
-        <p>{{ bag.desc }}</p>
+        <p>{{ bag.desc|e }}</p>
         </div>
         <div class="section" id="permissions">
         <p>You have the following permissions on this bag:</p>

--- a/tiddlywebplugins/templates/bags.html
+++ b/tiddlywebplugins/templates/bags.html
@@ -3,7 +3,7 @@
         <div class="section" id="bags">
         <ul class="listing">
         {%- for bag in bags -%}
-        <li><a href="/bags/{{ bag.name|uri }}/tiddlers">{{ bag.name }}</a></li>
+        <li><a href="/bags/{{ bag.name|uri }}/tiddlers">{{ bag.name|e }}</a></li>
         {%- endfor -%}
         </ul>
         </div>

--- a/tiddlywebplugins/templates/base.html
+++ b/tiddlywebplugins/templates/base.html
@@ -9,7 +9,7 @@
     <body>
         <div id="header">
         {% block title %}
-        <h1>{{ title }}</h1>
+        <h1>{{ title|e }}</h1>
         {% endblock %}
         </div>
         <div id="article">

--- a/tiddlywebplugins/templates/recipes.html
+++ b/tiddlywebplugins/templates/recipes.html
@@ -3,7 +3,7 @@
         <div class="section" id="recipes">
         <ul class="listing">
         {%- for recipe in recipes -%}
-        <li><a href="/recipes/{{ recipe.name|uri }}">{{ recipe.name }}</a></li>
+        <li><a href="/recipes/{{ recipe.name|uri }}">{{ recipe.name|e }}</a></li>
         {%- endfor -%}
         </ul>
         </div>

--- a/tiddlywebplugins/templates/tiddler.html
+++ b/tiddlywebplugins/templates/tiddler.html
@@ -6,17 +6,17 @@
 {% block title %}
         <h1>
         {% if space_link %}
-        <a href="{{ space_link }}" id='title'>{{ tiddler.title }}</a>
+        <a href="{{ space_link }}" id='title'>{{ tiddler.title|e }}</a>
         {% else %}
-        <span id="title">{{tiddler.title}}</span>
+        <span id="title">{{tiddler.title|e}}</span>
         {% endif %}
         </h1>
         <div id='links'>
           <a class="revisions" href="/bags/{{tiddler.bag|e}}/tiddlers/{{tiddler.title|e}}/revisions">revision</a> 
-          <a class="revision" href="/bags/{{tiddler.bag|e}}/tiddlers/{{tiddler.title|e}}/revisions/{{tiddler.revision}}">
-            {{tiddler.revision}}</a>
-          in bag <a class="bag" href="/bags/{{tiddler.bag|e}}">{{tiddler.bag}}</a>
-          {% if tiddler.recipe %}and recipe <a class="recipe" href="/recipes/{{tiddler.recipe}}">{{tiddler.recipe}}</a>{% endif %}
+          <a class="revision" href="/bags/{{tiddler.bag|e}}/tiddlers/{{tiddler.title|e}}/revisions/{{tiddler.revision|e}}">
+            {{tiddler.revision|e}}</a>
+          in bag <a class="bag" href="/bags/{{tiddler.bag|e}}">{{tiddler.bag|e}}</a>
+          {% if tiddler.recipe %}and recipe <a class="recipe" href="/recipes/{{tiddler.recipe}}">{{tiddler.recipe|e}}</a>{% endif %}
           in <a href="{{ list_link }}">this collection of tiddlers</a>
         </div>
 {% endblock %}
@@ -26,26 +26,26 @@
             <div class="tiddler">
               <div id="text-html" class="section">{{ html }}</div>
               <dl class="meta section">
-                  <dt>created</dt><dd>{{tiddler.created}}</dd>
-                  <dt>creator</dt><dd><a>{{tiddler.creator}}</a></dd>
-                  <dt>modified</dt><dd>{{tiddler.modified}}</dd>
-                  <dt>modifier</dt><dd><a>{{tiddler.modifier}}</a></dd>
+                  <dt>created</dt><dd>{{tiddler.created|e}}</dd>
+                  <dt>creator</dt><dd><a>{{tiddler.creator|e}}</a></dd>
+                  <dt>modified</dt><dd>{{tiddler.modified|e}}</dd>
+                  <dt>modifier</dt><dd><a>{{tiddler.modifier|e}}</a></dd>
                   {%- if tiddler.tags|length > 0 -%}
                   <dt>tags</dt>
-                  {% for i in tags %} <dd><a class="tag" href='/search?q=tag:"{{i|e}}"'>{{ i }}</a></dd>{% endfor %}
+                  {% for i in tags %} <dd><a class="tag" href='/search?q=tag:"{{i|e}}"'>{{ i|e }}</a></dd>{% endfor %}
                   {%- endif -%}
                   {%- if tiddler.fields['geo.lat'] and tiddler.fields['geo.long'] -%}
                   <dt>location</dt>
                   <dd>
                   <a class="geo" href="http://www.openstreetmap.org/?lat={{tiddler.fields['geo.lat']|e}}&lon={{tiddler.fields['geo.long']|e}}&zoom=14">
-                    latitude <span class="latitude" title="{{tiddler.fields['geo.lat']|e}}">{{tiddler.fields['geo.lat']}}</span>
-                    longitude <span class="longitude" title="{{tiddler.fields['geo.long']|e}}">{{tiddler.fields['geo.long']}}</span>
+                    latitude <span class="latitude" title="{{tiddler.fields['geo.lat']|e}}">{{tiddler.fields['geo.lat']|e}}</span>
+                    longitude <span class="longitude" title="{{tiddler.fields['geo.long']|e}}">{{tiddler.fields['geo.long']|e}}</span>
                   </a>
                   </dd>
                   {%- endif -%}
                   {%- for i in fields -%}
                     {%- if i not in reserved_fields -%}
-                      {%- if fields[i] -%}<dt>{{i}}</dt><dd>{{fields[i]}}</dd>{%- endif -%}
+                      {%- if fields[i] -%}<dt>{{i}}</dt><dd>{{fields[i]|e}}</dd>{%- endif -%}
                     {%- endif -%}
                   {%- endfor -%}
               </dl>

--- a/tiddlywebplugins/templates/tiddlers.html
+++ b/tiddlywebplugins/templates/tiddlers.html
@@ -21,17 +21,17 @@
             {%- for tiddler in tiddlers -%}
             <li><a href="/bags/{{ tiddler.bag|uri }}/tiddlers/{{
                 tiddler.title|uri }}/revisions/{{ tiddler.revision
-                }}">{{ tiddler.title }}:{{ tiddler.revision
+                }}">{{ tiddler.title|e }}:{{ tiddler.revision
                 }}</a></li>
             {%- endfor -%}
         {% else %}
             {%- for tiddler in tiddlers -%}
             {%- if tiddler.fields._canonical_uri -%}
             <li><a href="{{ tiddler.fields._canonical_uri }}">{{
-                tiddler.title }}</a></li>
+                tiddler.title|e }}</a></li>
             {%- else -%}
             <li><a href="/bags/{{ tiddler.bag|uri }}/tiddlers/{{
-                tiddler.title|uri }}">{{ tiddler.title }}</a></li>
+                tiddler.title|uri }}">{{ tiddler.title|e }}</a></li>
             {%- endif -%}
             {%- endfor -%}
         {% endif %}


### PR DESCRIPTION
if you have a tiddler called <<foo bar>> when rendered in the html
serialisation it attempts to render as a tag <foo bar

this prevents this from occuring by doing lots of escaping of things
that could be html

this prevents x site scripting attacks.
