### PR TITLE
use different name for mode

### DIFF
--- a/src/plugins/TiddlySpaceConfig.js
+++ b/src/plugins/TiddlySpaceConfig.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceConfig|
-|''Version''|0.7.6|
+|''Version''|0.7.7|
 |''Description''|TiddlySpace configuration|
 |''Status''|stable|
 |''Source''|http://github.com/TiddlySpace/tiddlyspace/raw/master/src/plugins/TiddlySpaceConfig.js|
@@ -274,13 +274,13 @@ if(fImport) {
 		var select = $('<select name="mode" />').appendTo(container)[0];
 		$('<option value="private" selected>private</a>').appendTo(select);
 		$('<option value="public">public</a>').appendTo(select);
-		wizard.setValue("mode", select);
+		wizard.setValue("importmode", select);
 		_createForm.apply(this, [place, wizard, iframeName]);
 	};
 
 	var _onGet = config.macros.importTiddlers.onGetTiddler;
 	config.macros.importTiddlers.onGetTiddler = function(context, wizard) {
-		var type = $(wizard.getValue("mode")).val();
+		var type = $(wizard.getValue("importmode")).val();
 		var ws =  plugin.getCurrentWorkspace(type);
 		wizard.setValue("workspace", ws);
 		_onGet.apply(this, [context, wizard]);


### PR DESCRIPTION
the wizard has a setValue method which wrongly treats a dom element
as a set of name value pairs. In IE6 and 7 dom elements have readonly
attributes mode which causes this to throw an error

this addresses #675
note a long term fix was suggested here:
http://github.com/TiddlyWiki/tiddlywiki/pull/36
