### PR TITLE
removed use of addClass

### DIFF
--- a/src/plugins/TiddlySpaceToolbar.js
+++ b/src/plugins/TiddlySpaceToolbar.js
@@ -2,7 +2,7 @@
 |''Name''|TiddlySpaceToolbar|
 |''Description''|augments tiddler toolbar commands with SVG icons|
 |''Author''|Osmosoft|
-|''Version''|0.6.5|
+|''Version''|0.6.6|
 |''Status''|@@beta@@|
 |''Source''|http://github.com/TiddlySpace/tiddlyspace/raw/master/src/plugins/TiddlySpaceToolbar.js|
 |''CodeRepository''|http://github.com/TiddlySpace/tiddlyspace|
@@ -98,7 +98,7 @@ macro.onClickMorePopUp = function(ev) {
 	if(sibling) {
 		var commands = sibling.childNodes;
 		var popup = Popup.create(this);
-		addClass(popup, "taggedTiddlerList");
+		$(popup).addClass("taggedTiddlerList");
 		for(var i = 0; i < commands.length; i++) {
 			var li = createTiddlyElement(popup, "li", null);
 			var oldCommand = commands[i];


### PR DESCRIPTION
Currently in spaces using the latest alpha you can't use the more menu.

This is because...

the addClass function has been deprecated in favour of
$.addClass

see https://github.com/TiddlyWiki/tiddlywiki/commit/feb3eb57b742e7a92a334d43fa16e9e025a430e7
