### PR TITLE
Link social

### DIFF
--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -152,16 +152,18 @@ var followMacro = config.macros.followTiddlers = {
 			callback(tweb.host, tiddlyspace.getHost(status.server_host, "%0"));
 		});
 	},
+	getBlacklist: function() {
+		return store.getTiddlerText("FollowTiddlersBlackList").split("\n");
+	},
 	handler: function(place, macroName, params, wikifier, paramString, tiddler) {
 		var args = paramString.parseParams("anon")[0];
 		var title = params[0] || tiddler.fields["server.title"] || tiddler.title;
 		var tid = store.getTiddler(title);
 		var user = params[1] || false;
-		var blacklisted = store.getTiddlerText("FollowTiddlersBlackList").split("\n");
 		if(tid) {
 			followMacro.makeButton(place, {
 				url: "/search?q=title:%0".format(encodeURIComponent(title)),
-				blacklisted: blacklisted, title: title, user: user,
+				blacklisted: followMacro.getBlacklist(), title: title, user: user,
 				consultFollowRelationship: args.follow ? true : false });
 		}
 	},
@@ -485,12 +487,11 @@ var linkedMacro = config.macros.linkedTiddlers = {
 		var args = paramString.parseParams("anon")[0];
 		var title = params[0] || tiddler.fields["server.title"] || tiddler.title;
 		var tid = store.getTiddler(title);
-		var blacklisted = store.getTiddlerText("FollowTiddlersBlackList").split("\n");
 		if(tid) {
 			followMacro.makeButton(place, {
 				url: "/bags/%0/tiddlers/%1/backlinks".format(tid.fields['server.bag'],
 					encodeURIComponent(tid.title)),
-				blacklisted: blacklisted, title: title, user: params[1] || false,
+				blacklisted: followMacro.getBlacklist(), title: title, user: params[1] || false,
 				consultFollowRelationship: args.follow ? true : false });
 		}
 	}

--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceFollowingPlugin|
-|''Version''|0.6.5|
+|''Version''|0.6.6|
 |''Description''|Provides a following macro|
 |''Author''|Jon Robson|
 |''Requires''|TiddlySpaceConfig TiddlySpaceTiddlerIconsPlugin ErrorHandler|

--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceFollowingPlugin|
-|''Version''|0.6.5|
+|''Version''|0.6.6|
 |''Description''|Provides a following macro|
 |''Author''|Jon Robson|
 |''Requires''|TiddlySpaceConfig TiddlySpaceTiddlerIconsPlugin ErrorHandler|
@@ -479,6 +479,22 @@ var followingMacro = config.macros.following = {
 		return !username ? followingCallback({ name: currentSpace }) : followingCallback({ name: username });
 	}
 };
+
+var linkedMacro = config.macros.linkedTiddlers = {
+	handler: function(place, macroName, params, wikifier, paramString, tiddler) {
+		var args = paramString.parseParams("anon")[0];
+		var title = params[0] || tiddler.fields["server.title"] || tiddler.title;
+		var tid = store.getTiddler(title);
+		var blacklisted = store.getTiddlerText("FollowTiddlersBlackList").split("\n");
+		if(tid) {
+			followMacro.makeButton(place, {
+				url: "/bags/%0/tiddlers/%1/backlinks".format(tid.fields['server.bag'],
+					encodeURIComponent(tid.title)),
+				blacklisted: blacklisted, title: title, user: params[1] || false,
+				consultFollowRelationship: args.follow ? true : false });
+		}
+	}
+}
 
 })(jQuery);
 //}}}

--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -11,6 +11,8 @@ Using the {{{<<followTiddlers X>>}}}
 will reveal the number of tiddlers with name X in the set of spaces the *current* user viewing your space follows.
 {{{<<following jon>>}}} will list all the users following Jon.
 {{{<<followers jon>>}}} will list all the followers of jon.
+{{{<linkedTiddlers>>}}} will list all tiddlers across TiddlySpace linked to the current tiddler
+{{{<linkedTiddlers follow:yes>>}}} will list all tiddlers across TiddlySpace that come from your list of followers
 adds spaceLink view type {{{<<view server.bag spaceLink>>}}} creates a link to the space described in server.bag
 {{{<<view server.bag spaceLink title>>}}} makes a link to the tiddler with title expressed in the field title in space server.bag
 If no name is given eg. {{{<<following>>}}} or {{{<<follow>>}}} it will default the current user.

--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceFollowingPlugin|
-|''Version''|0.6.6|
+|''Version''|0.6.5|
 |''Description''|Provides a following macro|
 |''Author''|Jon Robson|
 |''Requires''|TiddlySpaceConfig TiddlySpaceTiddlerIconsPlugin ErrorHandler|
@@ -494,6 +494,11 @@ var linkedMacro = config.macros.linkedTiddlers = {
 				consultFollowRelationship: args.follow ? true : false });
 		}
 	}
+}
+
+if(config.options.chkFollowTiddlersIsLinkedTiddlers) {
+	merge(config.macros.followTiddlers, config.macros.linkedTiddlers);
+	config.shadowTiddlers.FollowTiddlersHeading = "These are the other tiddlers that link to this tiddler.";
 }
 
 })(jQuery);

--- a/src/plugins/TiddlySpaceFollowingPlugin.js
+++ b/src/plugins/TiddlySpaceFollowingPlugin.js
@@ -172,40 +172,36 @@ var followMacro = config.macros.followTiddlers = {
 		var blacklisted = options.blacklisted;
 		var tiddler = store.getTiddler(title);
 		var btn = $('<div class="followButton" />').appendTo(place)[0];
-		var id = Math.random();
-		$(story.getTiddler(title)).data("followTiddlerQuery", id);
 		if(blacklisted.contains(title)) {
 			$(btn).remove();
 			return;
 		} else {
 			var user = options.user;
 			window.setTimeout(function() { // prevent multiple calls due to refresh
-				if($(story.getTiddler(title)).data("followTiddlerQuery") === id) {
-					tiddlyspace.scroller.registerIsVisibleEvent(title, function() {
-						var mkButton = function(followers, ignore) {
-							if(!followers && !ignore) {
-								$(btn).remove();
-							} else {
-								var scanOptions = { url: options.url,
-									spaceField: "bag", template: null, sort: "-modified",
-									callback: function(tiddlers) {
-										followMacro.constructInterface(btn, tiddlers);
-									}
-								};
-								if(!ignore) {
-									scanOptions.showBags = followMacro._getFollowerBags(followers);
-								}
-								scanOptions.hideBags = [tiddler.fields["server.bag"]];
-								scanMacro.scan(null, scanOptions, user);
-							}
-						};
-						if(options.consultFollowRelationship) {
-							followMacro.getFollowers(mkButton);
+				tiddlyspace.scroller.registerIsVisibleEvent(title, function() {
+					var mkButton = function(followers, ignore) {
+						if(!followers && !ignore) {
+							$(btn).remove();
 						} else {
-							mkButton([], true);
+							var scanOptions = { url: options.url,
+								spaceField: "bag", template: null, sort: "-modified",
+								callback: function(tiddlers) {
+									followMacro.constructInterface(btn, tiddlers);
+								}
+							};
+							if(!ignore) {
+								scanOptions.showBags = followMacro._getFollowerBags(followers);
+							}
+							scanOptions.hideBags = [tiddler.fields["server.bag"]];
+							scanMacro.scan(null, scanOptions, user);
 						}
-					});
-				}
+					};
+					if(options.consultFollowRelationship) {
+						followMacro.getFollowers(mkButton);
+					} else {
+						mkButton([], true);
+					}
+				});
 			}, 1000);
 		}
 	},


### PR DESCRIPTION
This puts the linkedTiddlers macro into the core.
It can be used alongside or as a replacement (with a config.option) for the default followTiddlers macro

How and if we do that is something to decide later.
