### PR TITLE
Html meta tags

### DIFF
--- a/tiddlywebplugins/templates/base.html
+++ b/tiddlywebplugins/templates/base.html
@@ -7,6 +7,12 @@
         {%- endfor -%}
         {% block links %}
         {% endblock %}
+        <link rel="icon" href="/favicon.ico">
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+        <meta name="title" content="{{ title|e }}" /> 
+        <meta name="image" content="/SiteIcon" /> 
+        <meta name="description" content="{{ meta_description|e }}"> 
+        <meta name="keywords" content="{{ meta_keywords|e }}"> 
     </head>
     <body>
         <div id="container">

--- a/tiddlywebplugins/tiddlyspace/htmlserialization.py
+++ b/tiddlywebplugins/tiddlyspace/htmlserialization.py
@@ -35,6 +35,8 @@ class Serialization(HTMLSerialization):
         Send recipes out recipes.html template.
         """
         return send_template(self.environ, 'recipes.html', {
+            'meta_keywords': 'recipes, tiddlyspace',
+            'meta_description': 'A list of recipes on TiddlySpace',
             'recipes': recipes,
             'title': 'Recipes'})
 
@@ -43,6 +45,8 @@ class Serialization(HTMLSerialization):
         Send bags out bags.html template.
         """
         return send_template(self.environ, 'bags.html', {
+            'meta_keywords': 'bags, tiddlyspace',
+            'meta_description': 'A list of bags on TiddlySpace',
             'bags': bags,
             'title': 'Bags'})
 
@@ -100,6 +104,8 @@ class Serialization(HTMLSerialization):
         tiddlers_url = tiddlers_url.rsplit('.html')[0]
 
         return send_template(self.environ, 'tiddlers.html', {
+            'meta_keywords': 'tiddlers, tiddlyspace',
+            'meta_description': 'A list of tiddlers on TiddlySpace',
             'title': title,
             'revisions': revisions,
             'tiddlers_url': tiddlers_url.decode('utf-8', 'replace'),
@@ -115,6 +121,8 @@ class Serialization(HTMLSerialization):
         Send a recipe out the recipe.html template.
         """
         return send_template(self.environ, 'recipe.html', {
+            'meta_keywords': 'recipe, tiddlyspace',
+            'meta_description': 'A recipe on TiddlySpace',
             'recipe': recipe,
             'title': 'Recipe %s' % recipe.name})
 
@@ -130,6 +138,8 @@ class Serialization(HTMLSerialization):
         user_perms = bag.policy.user_perms(user)
 
         return send_template(self.environ, 'bag.html', {
+            'meta_keywords': 'bag, tiddlyspace',
+            'meta_description': 'A bag on TiddlySpace',
             'policy': policy,
             'user_perms': user_perms,
             'bag': bag,
@@ -159,6 +169,8 @@ class Serialization(HTMLSerialization):
         space_link = self._space_link(tiddler)
         html = render_wikitext(tiddler, self.environ)
         return send_template(self.environ, 'tiddler.html', {
+            'meta_keywords': ', '.join(tiddler.tags),
+            'meta_description': 'A tiddler on TiddlySpace',
             'title': '%s' % tiddler.title,
             'tags': tiddler.tags,
             'fields': tiddler.fields,

--- a/tiddlywebplugins/tiddlyspace/htmlserialization.py
+++ b/tiddlywebplugins/tiddlyspace/htmlserialization.py
@@ -168,14 +168,9 @@ class Serialization(HTMLSerialization):
             container_policy = False
         space_link = self._space_link(tiddler)
         html = render_wikitext(tiddler, self.environ)
-        try:
-            description = tiddler.fields["summary"]
-        except KeyError:
-            description = 'A tiddler on TiddlySpace'
-
         return send_template(self.environ, 'tiddler.html', {
             'meta_keywords': ', '.join(tiddler.tags),
-            'meta_description': description,
+            'meta_description': tiddler.title,
             'title': '%s' % tiddler.title,
             'tags': tiddler.tags,
             'fields': tiddler.fields,

--- a/tiddlywebplugins/tiddlyspace/htmlserialization.py
+++ b/tiddlywebplugins/tiddlyspace/htmlserialization.py
@@ -168,9 +168,14 @@ class Serialization(HTMLSerialization):
             container_policy = False
         space_link = self._space_link(tiddler)
         html = render_wikitext(tiddler, self.environ)
+        try:
+            description = tiddler.fields["summary"]
+        except KeyError:
+            description = 'A tiddler on TiddlySpace'
+
         return send_template(self.environ, 'tiddler.html', {
             'meta_keywords': ', '.join(tiddler.tags),
-            'meta_description': 'A tiddler on TiddlySpace',
+            'meta_description': description,
             'title': '%s' % tiddler.title,
             'tags': tiddler.tags,
             'fields': tiddler.fields,


### PR DESCRIPTION
This adds widely used meta tags to the top of html pages generated in TiddlySpace.

Hopefully this will help with SEO and sharing html pages on TiddlySpace.
