### PR TITLE
remove whitespace before bag name

### DIFF
--- a/tiddlywebplugins/templates/tiddler.html
+++ b/tiddlywebplugins/templates/tiddler.html
@@ -33,9 +33,9 @@
               <dl class="meta section">
                   <dt>bag</dt>
                     <dd>
-                      {%- if container_policy -%}<a class="bag" href="/bags/{{tiddler.bag|uri}}">
-                      {%- else -%}<span class="bag">{%- endif %}
-                      {{tiddler.bag|e}}
+                      {%- if container_policy -%}<a class="bag" href="/bags/{{tiddler.bag|uri}}"
+                      {%- else -%}<span class="bag"{%- endif -%}
+                      >{{tiddler.bag|e}}
                       {%- if container_policy -%}</a>
                       {%- else -%}</span>{%- endif %}
                     </dd>


### PR DESCRIPTION
previously the text of the node with class span would have been "    bagname"
rather than "bagname" - this is incorrect
shifting the closing > to before the bag removes this whitespace
