### PR TITLE
When /tiddlers is access as a wiki read ServerSettings

### DIFF
--- a/test/test_web_use_instance.py
+++ b/test/test_web_use_instance.py
@@ -232,6 +232,17 @@ def test_space_server_settings_twrelease():
     assert response['status'] == '200'
     assert '/bags/common/tiddlers/alpha_jquery.js' not in content
 
+    response, content = http.request('http://foo.0.0.0.0:8080/tiddlers.wiki')
+    assert response['status'] == '200'
+    assert '/bags/common/tiddlers/alpha_jquery.js' not in content
+    assert 'TiddlyWiki created by Jeremy Ruston' in content
+
+    response, content = http.request('http://foo.0.0.0.0:8080/tiddlers',
+            headers={'Accept': 'text/x-tiddlywiki'})
+    assert response['status'] == '200'
+    assert '/bags/common/tiddlers/alpha_jquery.js' not in content
+    assert 'TiddlyWiki created by Jeremy Ruston' in content
+
     tiddler = Tiddler('ServerSettings', 'foo_public')
     tiddler.text = 'external: True\ntwrelease:alpha'
     store.put(tiddler)
@@ -239,6 +250,17 @@ def test_space_server_settings_twrelease():
     response, content = http.request('http://foo.0.0.0.0:8080/')
     assert response['status'] == '200', content
     assert '/bags/common/tiddlers/alpha_jquery.js' in content
+
+    response, content = http.request('http://foo.0.0.0.0:8080/tiddlers.lwiki')
+    assert response['status'] == '200', content
+    assert '/bags/common/tiddlers/alpha_jquery.js' in content
+    assert 'TiddlyWiki created by Jeremy Ruston' in content
+
+    response, content = http.request('http://foo.0.0.0.0:8080/tiddlers',
+            headers={'Accept': 'text/x-tiddlywiki'})
+    assert response['status'] == '200'
+    assert '/bags/common/tiddlers/alpha_jquery.js' in content
+    assert 'TiddlyWiki created by Jeremy Ruston' in content
 
     # bad content
     tiddler = Tiddler('ServerSettings', 'foo_public')

--- a/tiddlywebplugins/tiddlyspace/handler.py
+++ b/tiddlywebplugins/tiddlyspace/handler.py
@@ -77,7 +77,14 @@ def get_space_tiddlers(environ, start_response):
     whatever the reqeusted representation is. Choose recipe
     based on membership status.
     """
-    _setup_friendly_environ(environ)
+    space_name = _setup_friendly_environ(environ)
+    serializer, _ = get_serialize_type(environ)
+    # If we are a wiki read ServerSettings, but ignore index
+    if ('betaserialization' in serializer
+            or 'betalazyserialization' in serializer):
+        _, lazy = update_space_settings(environ, space_name)
+        if lazy:
+            environ['tiddlyweb.type'] = 'text/x-ltiddlywiki'
     return get_tiddlers(environ, start_response)
 
 
@@ -170,7 +177,7 @@ def _setup_friendly_environ(environ):
     """
     Manipulate the environ so that we appear to be in the context of the
     recipe appropriate for this current space and the current membership
-    status.
+    status. Return space_name to caller.
     """
     http_host, host_url = determine_host(environ)
     if http_host == host_url:
@@ -181,3 +188,4 @@ def _setup_friendly_environ(environ):
     recipe_name = determine_space_recipe(environ, space_name)
     environ['wsgiorg.routing_args'][1]['recipe_name'] = recipe_name.encode(
         'UTF-8')
+    return space_name


### PR DESCRIPTION
"as a wiki" means that the betaserialization or lazybetaserialization
is requested, via an Accept header or .wiki or .lwiki extensions.

We must only do the read on those serializations because reading
ServerSetting can change the query string and available filters,
which we don't want to do just any ol time.

fixes #735
