### PR TITLE
add _account and _space applications to a default space

### DIFF
--- a/src/system-applications/_account.tid
+++ b/src/system-applications/_account.tid
@@ -1,0 +1,131 @@
+type: text/html
+tags: excludeLists
+
+<html>
+<head>
+	<title>Account</title>
+	<link href="/bags/common/tiddlers/profile.css" type='text/css' rel='stylesheet' >
+	<link href="/bags/common/tiddlers/jquery-ui.custom.css" type='text/css' rel='stylesheet' >
+	<script type="text/javascript" src="/bags/common/tiddlers/backstage.js"></script>
+</head>
+<body>
+
+<div id="container">
+	<div id="header">
+		<h1>Account</h1>
+	</div>
+	<div class="main section">
+		<h2>Find Space</h2>
+		<form class="spaceSearch">
+			<input type="search" placeholder="search for space name" />
+		</form>
+		<h2>Create New Space</h2>
+		<form class="ts-spaces">
+			<input type="text" name="spacename" placeholder="name of new space"><span class="hostSuffix">.tiddlyspace.com</span>
+			<input type="submit" value="Create Space" />
+		</form>
+		<h2>Your Identities</h2>
+		<ul class="ts-identities"></ul>
+		<form class="ts-openid">
+			Add an openid
+			<input type="text" name="openid" placeholder="your openid" />
+			<input type="submit" value="Register" />
+			<a href="http://openid.net/get-an-openid/">What is an open id?</a>
+		</form>
+		<h2>Your Password</h2>
+		<form class="ts-password">
+			<input placeholder="existing password" type="password" name="password">
+			<input placeholder="new password" type="password" name="new_password">
+			<input placeholder="new password"	type="password" name="new_password_confirm">
+			<input type="submit" value="Change password">
+		</form>
+	</div>
+</div>
+<script type='text/javascript' src='/bags/common/tiddlers/jquery.js'></script>
+<script type='text/javascript' src='/bags/common/tiddlers/jquery-json.js'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.space'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.users'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.identities'></script>
+<script type='text/javascript' src="/bags/common/tiddlers/jquery-ui.custom.js"></script>
+<script type='text/javascript' src='/bags/common/tiddlers/ts.js'></script>
+<script type="text/javascript">
+/*
+ * jQuery UI Autocomplete HTML Extension
+ *
+ * Copyright 2010, Scott González (http://scottgonzalez.com)
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * http://github.com/scottgonzalez/jquery-ui-extensions
+ */
+(function( $ ) {
+
+var proto = $.ui.autocomplete.prototype,
+	initSource = proto._initSource;
+
+function filter( array, term ) {
+	var matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i" );
+	return $.grep( array, function(value) {
+		return matcher.test( $( "<div>" ).html( value.label || value.value || value ).text() );
+	});
+}
+
+$.extend( proto, {
+	_initSource: function() {
+		if ( this.options.html && $.isArray(this.options.source) ) {
+			this.source = function( request, response ) {
+				response( filter( this.options.source, request.term ) );
+			};
+		} else {
+			initSource.call( this );
+		}
+	},
+
+	_renderItem: function( ul, item) {
+		return $( "<li></li>" )
+			.data( "item.autocomplete", item )
+			.append( $( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.label ) )
+			.appendTo( ul );
+	}
+});
+
+})( jQuery );
+
+/***
+_accounts application specific javascript
+***/
+ts.init(function(ts) {
+	if(ts.user.anon) { // redirect to homepage when user not logged in
+		window.location = ts.getHost();
+	}
+	$(".hostSuffix").text("." + ts.getHost("").split("//")[1]);
+	ts.getSpaces(function(spaces) {
+		$("<div class='info' />").text("You have " + spaces.length + " spaces.").insertBefore($(".spaceSearch")[0]);
+		$("form.spaceSearch input").autocomplete({
+			html: true,
+			source: function(req, response) {
+				ts.getSpaces(function(spaces) {
+					var selected = [];
+					for(var i = 0; i < spaces.length; i++) {
+						var space = spaces[i];
+						if(space.name.indexOf(req.term) > -1) {
+							var host = ts.getHost(space.name) ;
+							var img = host + "/SiteIcon";
+							selected.push({
+								value: space.name,
+								label: '<a href="' + host + '"><img src="' + img + '" style="height:24px;width:auto;max-height:24px;max-width:24px;"/>' + space.name + '</a>'
+							});
+						}
+					}
+					response(selected);
+				});
+			},
+			select: function(event, ui) {
+				window.location = ts.getHost(ui.item.value);
+			}
+		});
+	});
+});
+</script>
+</body>
+</html>

--- a/src/system-applications/_space.tid
+++ b/src/system-applications/_space.tid
@@ -1,0 +1,126 @@
+type: text/html
+tags: excludeLists
+
+<html>
+<head>
+	<title>This Space</title>
+	<script type='text/javascript' src='/bags/common/tiddlers/backstage.js'></script>
+	<link href="/bags/common/tiddlers/profile.css" type='text/css' rel='stylesheet' >
+	<style type="text/css">
+		.ts-member .ts-membership {
+			display: none;
+		}
+	
+		#header h2 {
+			text-align: center;
+		}
+	</style>
+</head>
+<body>
+<div id="container">
+	<div id="header">
+		<h1 id='siteTitle'>This Space</h1>
+		<h2 id='siteUrl' class="meta"></h2>
+	</div>
+	<div id="text-html" class="main section">
+		<h2>About this space</h2>
+		<div id="siteinfo"></div>
+		<h2>Vital Statistics</h2>
+		<div id="info">please wait while information is loaded about this space...</div>
+		<div class="ts-membership">
+			<h2>Members</h2>
+			Your space currently has the following members...
+			<ul class="ts-members"></ul>
+			<p>Add a new member to your space by entering their name below. Enter a space to add all existing members of that space.</p>
+			<form class="ts-members">
+				<input type="text" name="username">
+				<input type="submit" value="Add Member" />
+			</form>
+		</div>
+		<div>
+			<h2>Included Spaces</h2>
+			<ul class="ts-includes"></ul>
+			<form class="ts-includes">
+				<input type="text" name="spacename">
+				<input type="submit" value="Include Space" />
+			</form>
+		</div>
+	</div>
+</div>
+<script type='text/javascript' src='/bags/common/tiddlers/jquery.js'></script>
+<script type='text/javascript' src='/bags/common/tiddlers/jquery-json.js'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.space'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.users'></script>
+<script type='text/javascript' src='/bags/tiddlyspace/tiddlers/chrjs.identities'></script>
+<script type='text/javascript' src="/bags/common/tiddlers/ts.js"></script>
+<script type="text/javascript">
+	ts.init(function(ts) {
+		if(!ts.currentSpace) {
+			return;
+		}
+		var address = window.location.hostname.split(".");
+		var spaceName = address[0];
+		var publicBag = spaceName + "_public";
+		$("#siteUrl").text(window.location.hostname);
+
+		function countTiddlers(members) {
+			var numMembers = members ? members.length : false;
+			var publicBagUrl = "/bags/" + spaceName + "_public/tiddlers";
+			var url = members ? "/bags/" + spaceName + "_private/tiddlers" :
+				publicBagUrl;
+			$.ajax({ url: url, dataType: "text",
+				success: function(tiddlers) {
+					var numTiddlers = $.trim(tiddlers).split("\n").length;
+					var html = "";
+					function printFullInfo(numPublicTiddlers) {
+						var totalTiddlers = numPublicTiddlers + numTiddlers;
+						html += ['This space has ', numMembers,
+							' members, <a href="/tiddlers">', totalTiddlers,
+							' local tiddlers</a>, <a href="' + url + '">',
+							numTiddlers, ' are private</a> and <a href="',
+							publicBagUrl, '">',
+							numPublicTiddlers, ' public</a>.'].join("");
+						$("#info").html(html);
+					}
+					if(numMembers) {
+						$.ajax({
+							url: publicBagUrl,
+							dataType: "text",
+							success: function(tiddlers) {
+								printFullInfo($.trim(tiddlers).split("\n").length);
+							}
+						});
+					} else {
+						html += 'This space has <a href="' + url + '">' + numTiddlers + " public tiddlers</a>";
+						$("#info").html(html);
+					}
+				}
+			});
+		}
+		var space = new tiddlyweb.Space(spaceName, "/");
+		space.members().get(function(members) {
+			countTiddlers(members);
+		}, function() {
+			countTiddlers();
+		});
+
+		new tiddlyweb.Tiddler("SiteInfo", new tiddlyweb.Bag(publicBag, "/")).get(
+			function(tid) {
+				$("#siteinfo").html(tid.render || tid.text);
+			},
+			function() {
+				$("#siteinfo").text("This space has not published any information about itself.");
+			}, "render=1");
+
+		new tiddlyweb.Tiddler("SiteTitle", new tiddlyweb.Bag(publicBag, "/")).get(
+			function(tid) {
+				$("#siteTitle").text(tid.text);
+			}, 
+			function() {
+				$("#siteTitle").text(window.location.hostname);
+			});
+	});
+</script>
+</body>
+</html>

--- a/src/system-applications/index.recipe
+++ b/src/system-applications/index.recipe
@@ -5,3 +5,5 @@ tiddler: appspagecss.tid
 tiddler: appspagejs.tid
 tiddler: https://raw.github.com/jdlrobson/notabene/master/dist/latest/HtmlJavascript.tid
 tiddler: https://raw.github.com/jdlrobson/notabene/master/dist/latest/htmljs-takenoteedit.js.js
+tiddler: _space.tid
+tiddler: _account.tid


### PR DESCRIPTION
this adds to each space an _account and _space app which allows you
note the _account app might make more sense on a special domain.

these apps have not been linked up the app switcher / backstage button
AND/OR other as its not clear yet how these might work

these 2 apps encapsulate all of the existing backstage functionality
that is not specific to tiddlywiki

the _ prefix has been used to eliminate name clashes

NOTE this assumes that chrjs.identities.js is available in the common bag
(see #743)
