### PR TITLE
Changed the title use use SiteIcon, etc if defined

### DIFF
--- a/src/system-applications/apps.tid
+++ b/src/system-applications/apps.tid
@@ -9,7 +9,6 @@ tags: excludeLists excludeSearch
 	<title>TiddlySpace Apps</title>
 	<link rel="stylesheet" href="http://tiddlyspace.com/bags/common/tiddlers/reset.css" />
 	<link rel="stylesheet" href="appspage.css" />
-	<link rel="stylesheet" href="/bags/common/tiddlers/backstage.css" />
 </head>
 <body>
 	
@@ -20,7 +19,7 @@ tags: excludeLists excludeSearch
 				<img class="siteicon">
 				<div id="title-subtitle">
 					<h1 class="spaceaddress">
-						<span class="spaceName"></span>.tiddlyspace.com
+						<span class="spaceName"></span><span class="hostName"></span>
 					</h1>
 					<p class="tagline"><span class="subTitle"></span><a class="managespaces inactive" href="/ManageSpaces">manage space</a></p>
 				</div>

--- a/src/system-applications/apps.tid
+++ b/src/system-applications/apps.tid
@@ -9,6 +9,7 @@ tags: excludeLists excludeSearch
 	<title>TiddlySpace Apps</title>
 	<link rel="stylesheet" href="http://tiddlyspace.com/bags/common/tiddlers/reset.css" />
 	<link rel="stylesheet" href="appspage.css" />
+	<link rel="stylesheet" href="/bags/common/tiddlers/backstage.css" />
 </head>
 <body>
 	
@@ -16,12 +17,12 @@ tags: excludeLists excludeSearch
 		<div id="TSbar"></div>
 		<div id="main-content">
 			<div id="space-details">
-				<img class="siteicon" src="http://placehold.it/100x100">
+				<img class="siteicon">
 				<div id="title-subtitle">
 					<h1 class="spaceaddress">
-						<span>SPACENAME</span>.tiddlyspace.com
+						<span class="spaceName"></span>.tiddlyspace.com
 					</h1>
-					<p class="tagline">your space's tagline... <a class="managespaces inactive" href="/ManageSpaces">manage space</a></p>
+					<p class="tagline"><span class="subTitle"></span><a class="managespaces inactive" href="/ManageSpaces">manage space</a></p>
 				</div>
 			</div>
 			<div id="holder">
@@ -89,7 +90,12 @@ tags: excludeLists excludeSearch
 		</div>
 	</div>
 	
+	<script type="text/javascript" src="/bags/common/tiddlers/backstage.js"></script>
+	<script type="text/javascript" src="/bags/common/tiddlers/bookmark_bubble.js"></script>
 	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+	<script type="text/javascript" src="/bags/tiddlyspace/tiddlers/chrjs"></script>
+	<script type="text/javascript" src="/bags/common/tiddlers/chrjs-store.js"></script>
+	<script type="text/javascript" src="/bags/common/tiddlers/jquery-json.js"></script>
 	<script type="text/javascript" src="appspage.js"></script>
 </body>
 </html>

--- a/src/system-applications/appspagecss.tid
+++ b/src/system-applications/appspagecss.tid
@@ -31,6 +31,7 @@ body {
 	border-radius: 2px;
 	float: left;
 	margin-right: 2em;
+	height: 100px;
 }
 
 #title-subtitle {

--- a/src/system-applications/appspagecss.tid
+++ b/src/system-applications/appspagecss.tid
@@ -75,7 +75,7 @@ h1 {
 	font-size: 2em;
 }
 
-h1 span {
+h1 .spaceName {
 	color: #0059AF;
 	color: #0082AF;
 	font-size: 1.5em;

--- a/src/system-applications/appspagejs.tid
+++ b/src/system-applications/appspagejs.tid
@@ -1,24 +1,51 @@
 title: appspage.js
 tags: excludeLists excludeSearch
 type: text/javascript
-modifier: colmbritton
+modifier: osmosoft
 
 (function($){
-	
+
 	$(function(){
-		
+
+		// get some default tiddlers
+		var store = tiddlyweb.Store(null, false);
+		store.getDefaults(function(containers) {
+			var spaceName = containers.pullFrom.name.replace(/_[^_]+$/,'');
+			$('#title-subtitle .spaceName').text(spaceName);
+			store.get(new tiddlyweb.Tiddler({
+				title: 'SiteSubtitle',
+				bag: containers.pushTo
+			}), function(tiddler) {
+				if (tiddler) {
+					$('#title-subtitle .subTitle').text(tiddler.text);
+				} else {
+					$('#title-subtitle .subTitle').text('a TiddlySpace');
+				}
+			}).get(new tiddlyweb.Tiddler({
+				title: 'SiteIcon',
+				bag: containers.pushTo
+			}), function(tiddler) {
+				if (tiddler) {
+					$('#space-details .siteicon').attr('src', tiddler.route());
+				} else {
+					$('#space-details .siteicon')
+						.attr('src', '/bags/common/tiddlers/defaultSiteIcon');
+				}
+			});
+		});
+
 		$('#app-list li').mouseover(function() {
-		  	var me = $(this),
+			var me = $(this),
 				appname = me.attr("class"),
 				descEl = '.' + appname + 'desc';
 			$(descEl).addClass("highlightdesc");
 		}).mouseout(function() {
-		  	var me = $(this),
-			appname = me.attr("class"),
-			descEl = '.' + appname + 'desc';
+			var me = $(this),
+				appname = me.attr("class"),
+				descEl = '.' + appname + 'desc';
 			$(descEl).removeClass("highlightdesc");
 		});
-		
+
 		$(".inactive").click(function() {
 			var me = $(this),
 				oldtext = me.text();
@@ -29,7 +56,7 @@ modifier: colmbritton
 			});
 			return false;
 		});
-		
+
 		$(".soon").click(function() {
 			var me = $(this),
 				comingsoon = $('.comingsoon', me);
@@ -40,7 +67,7 @@ modifier: colmbritton
 			});
 			return false;
 		});
-		
+
 	});
-	
+
 })(jQuery);

--- a/src/system-applications/appspagejs.tid
+++ b/src/system-applications/appspagejs.tid
@@ -11,7 +11,18 @@ modifier: osmosoft
 		var store = tiddlyweb.Store(null, false);
 		store.getDefaults(function(containers) {
 			var spaceName = containers.pullFrom.name.replace(/_[^_]+$/,'');
-			$('#title-subtitle .spaceName').text(spaceName);
+			$.ajax({
+				url: '/status',
+				dataType: 'json',
+				success: function(data) {
+					var hostName = '.' + data.server_host.host || '';
+					$('#title-subtitle .spaceName').text(spaceName);
+					$('#title-subtitle .hostName').text(hostName);
+				},
+				error: function() {
+					$('#title-subtitle .spaceName').text(spaceName);
+				}
+			});
 			store.get(new tiddlyweb.Tiddler({
 				title: 'SiteSubtitle',
 				bag: containers.pushTo


### PR DESCRIPTION
The title now defaults to the same as the TiddlyWiki representation (the
defaultSiteIcon and the tagline of "a TiddlySpace"). If the user has a
SiteIcon of their own, or a SiteSubtitle, then it will use that instead.
