### PR TITLE
Ensure footer stays at bottom of screen even if displayed on large screen

### DIFF
--- a/src/system-applications/apps.tid
+++ b/src/system-applications/apps.tid
@@ -9,6 +9,9 @@ tags: excludeLists excludeSearch
 	<title>TiddlySpace Apps</title>
 	<link rel="stylesheet" href="http://tiddlyspace.com/bags/common/tiddlers/reset.css" />
 	<link rel="stylesheet" href="appspage.css" />
+	<!--[if lt IE 7 ]>
+	<link rel="stylesheet" href="appspageie6.css" />
+	<![endif]-->
 </head>
 <body>
 	

--- a/src/system-applications/appspagecss.tid
+++ b/src/system-applications/appspagecss.tid
@@ -3,9 +3,19 @@ type: text/css
 tags: excludeLists excludeSearch
 modifier: colmbritton
 
+html,
+body {
+	height: 100%;
+}
+
 body {
 	font-family: "helvetica neue";
 	font-size: 16px;
+}
+
+#wrapper {
+	min-height: 100%;
+	position: relative;
 }
 
 #TSbar {
@@ -18,7 +28,7 @@ body {
 
 #main-content {
 	margin: 0 auto;
-	padding-top: 2em;
+	padding: 2em 0 5em; /* original 3em + footer size */
 	width: 960px;
 }
 
@@ -244,7 +254,10 @@ h1 .spaceName {
 
 #footer {
 	background: #1A1F1E;
-	margin-top: 3em;
+	height: 1.375em;
+	width: 100%;
+	position: absolute;
+	bottom: 0;
 	padding: 0.3em 0;
 	clear: both;
 }
@@ -252,7 +265,7 @@ h1 .spaceName {
 #footer-content {
 	color: #B2AAA4;
 	font-size: 0.8em;
-	line-height: 1.3em;
+	line-height: 1.8em;
 	margin: 0 auto;
 	width: 960px;
 }

--- a/src/system-applications/appspagecssie6.tid
+++ b/src/system-applications/appspagecssie6.tid
@@ -1,0 +1,8 @@
+title: appspageie6.css
+type: text/css
+tags: excludeLists excludeSearch
+modifier: colmbritton
+
+#container {
+   height:100%;
+}


### PR DESCRIPTION
Ensure footer stays at bottom of screen even if displayed on large screen which the content doesn't fill

Done this in response to https://github.com/TiddlySpace/tiddlyspace/issues/754
