### PR TITLE
force backstage to check membership to current space

### DIFF
--- a/src/apps/app.css
+++ b/src/apps/app.css
@@ -92,3 +92,11 @@ form input[type=submit] {
 	font-size: 0.5em;
 	color: #B8B6BD;
 }
+
+.write {
+	opacity: 0.1;
+}
+
+.ts-member .write {
+	opacity: 1;
+}

--- a/src/apps/backstage.tid
+++ b/src/apps/backstage.tid
@@ -61,13 +61,15 @@ tags: excludeLists
 <script type='text/javascript' src='/bags/common/tiddlers/jquery.js'></script>
 <script type="text/javascript" src="/bags/tiddlyspace/tiddlers/chrjs"></script>
 <script type="text/javascript" src="/bags/tiddlyspace/tiddlers/chrjs.users"></script>
+<script type="text/javascript" src="/bags/tiddlyspace/tiddlers/chrjs.space"></script>
 <script type="text/javascript" src="/bags/common/tiddlers/ts.js"></script>
 <script type="text/javascript">
 	if(window.location.hash === "#refreshParent") {
 		window.location.hash = "";
 		window.parent.location.reload();
 	}
-	ts.init(null, { space: false });
+	ts.init(function(ts) {
+	}, {});
 </script>
 </body>
 </html>


### PR DESCRIPTION
when no space is passed to the ts init function it reads the
current domain name for the current space (note where the domain
name is the same as the host in /status ts.js returns no space so
we don't need to worry about when this is run of the root)

when a space is passed, membership is checked and the body is given
a class showing the current state. The css rules make use of this
to grey/gray out the write button in the apps list to hint that it
is disabled but also allow a user to still navigate to it.
