### PR TITLE
only show the backstage button in top level windows

### DIFF
--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -218,6 +218,8 @@ var loadEvent = function() {
 	});
 };
 
-addEventListener(window, "load", loadEvent);
+if(window == top) { // only add the backstage when NOT in an iframe (top window)
+	addEventListener(window, "load", loadEvent);
+}
 
 })();


### PR DESCRIPTION
the backstage button doesn't really make sense in a confined space
such as an iframe.

TiddlyWiki's backstage experiments in http://backstage.tiddlyspace.com
raised this issue. It also allows you to do weird things such as have
a TiddlyWiki within a TiddlyWiki within a TiddlyWiki by continually clicking
the tiddlywiki link in the menu.. eek!
