### PR TITLE
remove preso from apps page and backstage icon

### DIFF
--- a/src/apps/backstage.tid
+++ b/src/apps/backstage.tid
@@ -46,12 +46,6 @@ _cache-max-age: 3600
 			TIDDLYWIKI
 		</a>
 	</li>
-	<li class="preso">
-		<a href="/present"  target="_parent">
-			<img src="/bags/common/tiddlers/preso_blue.png" alt="Icon for Preso" class="app-img" />
-			PRESO
-		</a>
-	</li>
 	<li class="apps">
 		<a href="/apps"  target="_parent">
 			<img src="/bags/common/tiddlers/box_closed_blue.png" alt="Icon for Apps" class="app-img" />

--- a/src/system-applications/apps.tid
+++ b/src/system-applications/apps.tid
@@ -55,12 +55,6 @@ tags: excludeLists excludeSearch
 									TIDDLYWIKI
 								</a>
 							</li>
-							<li class="preso">
-								<a href="/present">
-									<img src="/bags/common/tiddlers/preso_blue.png" alt="Icon for Preso" class="app-img" />
-									PRESO
-								</a>
-							</li>
 						</ul>
 						<div id="addapp">
 							<button class="inactive">Add More!</button>


### PR DESCRIPTION
see #836 for rationale.
