### PR TITLE
hide login form altogether when logged in

### DIFF
--- a/src/apps/app.css
+++ b/src/apps/app.css
@@ -102,6 +102,7 @@ form input[type=submit] {
 	opacity: 1;
 }
 
+.ts-loggedin .login-method:target,
 .login-method {
 	display: none;
 }


### PR DESCRIPTION
when logged in, we shouldn't let .login-method:target
override .ts-loggedin .ts-login css rule at the top of the
stylesheet
