### PR TITLE
make login visible on firefox

### DIFF
--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -152,7 +152,7 @@ var loadEvent = function() {
 	body.insertBefore(link, body.firstChild);
 	var html = [
 	'<div class="bubble">',
-	    '<iframe src="/bags/common/tiddlers/backstage" width="auto" style="border:none;"></iframe>',
+	    '<iframe src="/bags/common/tiddlers/backstage#userpass-login" width="auto" style="border:none;"></iframe>',
 	    '<div class="tail"></div>',
 	'</div>'].join("");
 	var bubble = document.createElement("div");


### PR DESCRIPTION
a strange bug - see https://bugzilla.mozilla.org/show_bug.cgi?id=713845
is preventing the login box from showing.
It seems by setting the hash via the src parameter we can get it to
render.
