### PR TITLE
prevent excessive ajax requests in older versions of firefox

### DIFF
--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -157,7 +157,7 @@ var loadEvent = function() {
 	'</div>'].join("");
 	var bubble = document.createElement("div");
 	bubble.setAttribute("id", "bs-popup");
-	bubble.style.cssText = "display:none;";
+	bubble.style.cssText = "visibility:hidden;";
 	bubble.className = "bs-popup";
 	bubble.innerHTML = html;
 	body.insertBefore(bubble, link);
@@ -176,7 +176,7 @@ var loadEvent = function() {
 			opacity = fadeIn ? opacity + 0.1 : opacity - 0.1;
 			if(opacity < 0 || opacity > 1) {
 				clearInterval(bubbleFadeInterval);
-				el.style.cssText = fadeIn ? "" : "display:none;";
+				el.style.cssText = fadeIn ? "" : "visibility:hidden;";
 			}
 		}, 50);
 	}


### PR DESCRIPTION
in firefox 5.0 the backstage triggers lots of /status requests until
it is opened putting unnecessary strain on the server

cdent discovered:
http://support.mozilla.com/en-US/questions/877508

it seems that the iframe will continually refresh until the backstage button
is clicked and the iframe displayed. using visibility instead of display solves
this. note because it is absolutely positioned no known side effects to how
page is rendered
