### PR TITLE
make title optional

### DIFF
--- a/src/plugins/TiddlySpaceLinkPlugin.js
+++ b/src/plugins/TiddlySpaceLinkPlugin.js
@@ -3,7 +3,7 @@
 |''Description:''|Formatter to reference other spaces from wikitext |
 |''Author:''|PaulDowney (psd (at) osmosoft (dot) com) |
 |''Source:''|http://github.com/TiddlySpace/tiddlyspace/raw/master/src/plugins/TiddlySpaceLinkPlugin.js|
-|''Version:''|1.3.1|
+|''Version:''|1.4.1|
 |''License:''|[[BSD License|http://www.opensource.org/licenses/bsd-license.php]] |
 |''Comments:''|Please make comments at http://groups.google.co.uk/group/TiddlyWikiDev |
 |''~CoreVersion:''|2.4|
@@ -50,8 +50,10 @@ function createSpaceLink(place, spaceName, title, alt, isBag) {
 		currentSpaceName = false;
 	}
 
-	a = jQuery("<a />").addClass('tiddlySpaceLink externalLink').attr('tiddler', title).
-		appendTo(place)[0];
+	a = jQuery("<a />").addClass('tiddlySpaceLink externalLink').appendTo(place)[0];
+	if(title) {
+		jQuery(a).attr('tiddler', title);
+	}
 	if(isBag) {
 		jQuery(a).attr('bag', spaceName);
 	} else {


### PR DESCRIPTION
this fixes a problem identified in #859
<<view server.bag spaceLink>>
should generate a space link to the space identified by the server.bag field
no title is provided in this situation thus it is currently broken

TODO: I looked at porting the existing tests from
http://svn.tiddlywiki.org/Trunk/contributors/PaulDowney/plugins/TiddlySpaceLinkPlugin/test/
to minimise these sorts of problems
however these require porting the TiddlyWiki wikifier code.
either need to do this or rewrite the tests
