### PR TITLE
this updates status to work on non-existance spaces

### DIFF
--- a/test/test_web_status.py
+++ b/test/test_web_status.py
@@ -21,12 +21,24 @@ def setup_module(module):
     httplib2_intercept.install()
     wsgi_intercept.add_wsgi_intercept('0.0.0.0', 8080, app_fn)
     wsgi_intercept.add_wsgi_intercept('thing.0.0.0.0', 8080, app_fn)
+    wsgi_intercept.add_wsgi_intercept('unclaimed-space.0.0.0.0', 8080, app_fn)
     module.http = httplib2.Http()
     make_fake_space(store, 'thing')
 
 def teardown_module(module):
     import os
     os.chdir('..')
+
+def test_status_unclaimed_space():
+    response, content = http.request('http://unclaimed-space.0.0.0.0:8080/status')
+    assert response['status'] == '200'
+    info = simplejson.loads(content)
+
+    assert info['username'] == 'GUEST'
+    assert info['tiddlyspace_version'] == VERSION
+    assert info['server_host']['host'] == '0.0.0.0'
+    assert info['server_host']['port'] == '8080'
+    assert 'space' not in info
 
 def test_status_base():
     response, content = http.request('http://0.0.0.0:8080/status')

--- a/tiddlywebplugins/tiddlyspace/fixups.py
+++ b/tiddlywebplugins/tiddlyspace/fixups.py
@@ -3,6 +3,7 @@ Override behaviors from other modules.
 """
 
 import tiddlyweb.web.util
+from tiddlyweb.web.http import HTTP404
 import tiddlywebplugins.status
 
 from tiddlywebplugins.tiddlyspace.space import Space
@@ -31,8 +32,11 @@ def _status_gather_data(environ):
     http_host, host_url = determine_host(environ)
     if http_host != host_url:
         space_name = determine_space(environ, http_host)
-        recipe_name = determine_space_recipe(environ, space_name)
-        data['space'] = {'name': space_name, 'recipe': recipe_name}
+        try:
+            recipe_name = determine_space_recipe(environ, space_name)
+            data['space'] = {'name': space_name, 'recipe': recipe_name}
+        except HTTP404:
+            pass
 
     # ensure user is known
     usersign = environ['tiddlyweb.usersign']['name']


### PR DESCRIPTION
this allows a logged in user to easily claim a space from a 404 page
this addresses issue #825

I've run tests twice. On one occasion test_web_use_instance.py failed but when I ran it again it passed so could someone please verify I haven't broken anything and this was just a fluke before merging this?
