### PR TITLE
add missing DOCTYPE

### DIFF
--- a/src/apps/backstage.tid
+++ b/src/apps/backstage.tid
@@ -2,6 +2,7 @@ type: text/html
 tags: excludeLists
 _cache-max-age: 14400
 
+<!DOCTYPE HTML>
 <html>
 <head>
 <link rel="stylesheet" href="/bags/common/tiddlers/reset.css" />


### PR DESCRIPTION
adding the DOCTYPE actually makes issue #866 go away so that's rather
nice. Without it it renders incorrectly - I guess IE has some weirdness
at guessing missing DOCTYPES which causes issues in the rendering engine
