### PR TITLE
Disable apps

### DIFF
--- a/src/system-info/GettingStarted.tid
+++ b/src/system-info/GettingStarted.tid
@@ -2,22 +2,16 @@ type: None
 tags: excludeSearch excludeLists excludeMissing
 modifier: osmosoft
 
-Welcome to your brand new [[TiddlySpace]]@glossary. If you're a first time ~TiddlySpace user then there are a few things we should tell you to help get you started.  If you're already familiar with the application, or have used [[TiddlyWiki|http://tiddlywiki.org]] then you'll probably want to dive right in.
-!The basics
-* Documentation for ~TiddlySpace is constantly evolving and you can find ~FAQs, guidelines and a glossary in the @docs space
-* If you can't find the answer you're looking for in the @docs space then the community hanging out in [[Google Groups|https://groups.google.com/group/tiddlywiki?hl=en]] are likely to be able to help
-* You can edit, view and manipulate your content using a variety of ~TiddlySpace apps. You can vist the [[apps switcher|/apps]] to find out more
-* To get an idea of how others are using ~TiddlySpace you can take a look through the @featured space
-!Making your ~TiddlySpace your own
-At the moment your ~TiddlySpace is empty so there are a couple of things you should do to make it your own.
+Welcome to your brand new [[TiddlySpace]]@glossary.
 
-<<slider chkColorScheme [[colorScheme]] "Changing the color scheme »" "Changing the color scheme">>
+You're almost ready to go, there are just a couple of things left to do.
 
-<<slider chkSiteIcon [[spaceIcon]] "Giving your space an icon »" "Giving your space an icon">>
+!Customise your space
+Go to [[SpaceSettings]] to finish customising  your space. When you're done, come back here. Don't worry though, this will still be open when you've finished.
 
-<<slider chkSpaceTitle [[spaceTitle]] "Giving your space a title »" "Giving your space a title">>
+!Finished customising?
+You can [[Start writing]] some [[tiddlers|Tiddler]]@glossary.
+If you're not done tweaking yet though, you can always [[Customise this space|SpaceSettings]] a bit more.
 
-<<slider chkDefaultTiddlers [[setDefaultTiddlers]] "Setting default tiddlers »" "Setting default tiddlers">>
-!Some advanced stuff
-If you want to find out about some of the more advanced features, such as customising the [[CSS|http://docs.tiddlyspace.com/#%5B%5BStyleSheet%20shadow%20tiddlers%5D%5D]], [[including plugins|http://docs.tiddlyspace.com/#%5B%5BPluginManager%20shadow%20tiddlers%5D%5D]], [[developer resources|http://docs.tiddlyspace.com/#%5B%5BDeveloper%20Resources%5D%5D]] etc visit the @docs space.
-
+!Stuck?
+If you're stuck, and would like some help, please visit the @help space, which can point you in the right direction.

--- a/src/system-info/How to socialise.tid
+++ b/src/system-info/How to socialise.tid
@@ -1,0 +1,19 @@
+type: None
+tags: excludeSearch excludeLists excludeMissing
+modifier: osmosoft
+
+There are a lot of interesting people using ~TiddlySpace that you might like to keep track of and interact with. There are two main ways of doing this.
+
+Firstly, if you see a number in the speech bubble in one of your tiddlers, it means that someone is writing about the same thing as you. You can find out what they're saying by clicking on it.
+
+Secondly, if you find anyone interesting, or you find an interesting looking space and you'd like to know when it's changed, you can "follow" that space. To do this, simply create a tiddler with the title: {{{@space-name}}} and tag it {{{follow}}}. If you want, you can store some notes about that space in the body of the tiddler.
+
+If you then want to know what happening, simply [[include|How do I include/exclude spaces?]]@docs the @tivity space and then visit your activity stream at [[/activity|/activity]], or just visit the @tapas space directly.
+
+!Not sure who to follow?
+Here's a few suggestions:
+* @fnd
+* @cdent
+* @pmario
+* @bengillies
+* @dickon

--- a/src/system-info/SpaceSettings.tid
+++ b/src/system-info/SpaceSettings.tid
@@ -1,0 +1,30 @@
+type: None
+tags: excludeSearch excludeLists excludeMissing
+modifier: osmosoft
+
+!Upload an icon
+<<tiddler spaceIcon>>
+
+!Describe your space
+If you haven't already done so, you should provide a brief decscription of yourself and what you're using this space for. To do this, just edit the [[SiteInfo]] tiddler (keeping the title the same of course).
+----
+
+!Change the title
+<<tiddler spaceTitle>>
+
+!Change the color scheme
+<<tiddler colorScheme>>
+
+!Change the menu
+If you'd like to change the menu items along the top, you can edit the [[MainMenu]] tiddler.
+----
+
+!Change the default tiddlers
+<<tiddler setDefaultTiddlers>>
+
+!More Advanced customisations
+If you know HTML and CSS, you can edit some or all of the following tiddlers to customise your space further:
+* PageTemplate
+* EditTemplate
+* ViewTemplate
+* StyleSheet

--- a/src/system-info/Start writing.tid
+++ b/src/system-info/Start writing.tid
@@ -1,0 +1,21 @@
+type: None
+tags: excludeSearch excludeLists excludeMissing
+modifier: osmosoft
+
+Click the "new tiddler" button towards the top right of the screen to write something in your space. You'll need to give it a title, some content and, optionally, some tags that will help you identify it later.
+
+!Stuck for ideas?
+Not sure what to write about? Not sure what to keep in your space? Other people use ~TiddlySpace for almost anything. How about some of the following:
+
+* [[Save interesting sites|http://bookmarks.tiddlyspace.com]], images or articles from around the web so that you can refer back to them.
+* [[Record your family tree|http://familytree.tiddlyspace.com]], store notes on long lost relatives or ancestors and map their relationship to you.
+* [[Make up a pocketbook|http://pocketbook.tiddlyspace.com]] to store some useful information in, then print it out, [[fold it up|http://www.pocketmod.com/]], and take it with you.
+* [[Plan your holiday|http://the-web-is-your-oyster.tiddlyspace.com/]], record where you're planning to go, note down places of interest and refer back to it later.
+* [[Create a mindmap|http://mindmaps.tiddlyspace.com/]] to visualise your inner thoughts and see how they relate to each other.
+* [[Set up a questionnaire|http://questionnaire.tiddlyspace.com/]] and get all your friends to answer it.
+
+If you don't like any of those ideas, you can still use this space directly to keep notes and link them together, make a todo list and keep track of everything you're doing, or any one of a hundred million other things.
+
+Still stuck? Check out the @featured space for more suggestions.
+
+You can also [[socialise with others|How to socialise]].

--- a/src/system-info/index.recipe
+++ b/src/system-info/index.recipe
@@ -5,3 +5,6 @@ tiddler: colorScheme.tid
 tiddler: setDefaultTiddlers.tid
 tiddler: spaceIcon.tid
 tiddler: spaceTitle.tid
+tiddler: How to socialise.tid
+tiddler: SpaceSettings.tid
+tiddler: Start writing.tid

--- a/test/test_web_use_instance.py
+++ b/test/test_web_use_instance.py
@@ -324,6 +324,9 @@ def test_space_server_settings_index():
     assert 'TiddlyWiki' not in content
     assert 'TiddlyWeb' not in content
 
+# XXX: Disable until app switcher is re-enabled as default
+# TODO: Re-enable test when app swither is re-enabled as default
+"""
 def test_new_space_loads_apps():
     http = httplib2.Http()
     tiddler = Tiddler('ServerSettings', 'foo_public')
@@ -336,3 +339,4 @@ def test_new_space_loads_apps():
     response, appsContent = http.request('http://foo.0.0.0.0:8080/apps')
     assert response['status'] == '200'
     assert appsContent == defaultContent
+"""

--- a/tiddlywebplugins/tiddlyspace/serversettings.py
+++ b/tiddlywebplugins/tiddlyspace/serversettings.py
@@ -92,6 +92,10 @@ def _figure_default_index(environ, bag_name, space):
     the new default: the app switcher. The presence of a spaceSetupFlag
     tiddler is the test for this.
     """
+    pass
+    # XXX: Disable the default new user app switcher temporarily
+    # TODO: Turn this back on when the app switcher is more complete
+    """
     store = environ['tiddlyweb.store']
     index = environ['tiddlyweb.space_settings']['index']
     if not index and space.name != 'frontpage':
@@ -105,3 +109,4 @@ def _figure_default_index(environ, bag_name, space):
             except NoTiddlerError:
                 environ['tiddlyweb.space_settings']['index'] \
                         = DEFAULT_NEWUSER_APP
+    """


### PR DESCRIPTION
This temporarily disables the app switcher (note that it is still accessible from the /apps uri) so that it is no longer the default page that loads up on new spaces.
