### PR TITLE
Improved the color scheme/theme switcher text

### DIFF
--- a/src/system-info/SpaceSettings.tid
+++ b/src/system-info/SpaceSettings.tid
@@ -4,24 +4,18 @@ modifier: osmosoft
 
 !Upload an icon
 <<tiddler spaceIcon>>
-
 !Describe your space
 If you haven't already done so, you should provide a brief decscription of yourself and what you're using this space for. To do this, just edit the [[SiteInfo]] tiddler (keeping the title the same of course).
-----
 
 !Change the title
 <<tiddler spaceTitle>>
-
-!Change the color scheme
+!Change the theme
 <<tiddler colorScheme>>
-
 !Change the menu
 If you'd like to change the menu items along the top, you can edit the [[MainMenu]] tiddler.
-----
 
 !Change the default tiddlers
 <<tiddler setDefaultTiddlers>>
-
 !More Advanced customisations
 If you know HTML and CSS, you can edit some or all of the following tiddlers to customise your space further:
 * PageTemplate

--- a/src/system-info/colorScheme.tid
+++ b/src/system-info/colorScheme.tid
@@ -2,8 +2,15 @@ modifier: osmosoft
 type: None
 tags: excludeLists excludeSearch
 
-Unless you're delighted with the default scheme you can make some quick changes by generating a new random color palette, hit this button to cycle through some alternatives.
+Unless you're delighted with the default theme you can make some quick changes by generating a new random color palette, hit this button to cycle through some alternatives.
 
 <<RandomColorPaletteButton saturation_pale:0.67 saturation_light:0.53
 saturation_mid:0.43 saturation_dark:0.06 pale:0.99 light:0.85 mid:0.5 dark:0.31>>
-<html><hr><html>
+
+You can also change the look and feel completely by installing a new theme. To do this, find one you like in the @themes space, note down the name, and include it in this space by going to the space menu at the top-left of this page. Here are a few of our favourites:
+* @pip
+* @caspian-ii
+* @basalt
+* @simplicity
+* @cheesecake
+* @jelly-doughnut

--- a/src/system-info/setDefaultTiddlers.tid
+++ b/src/system-info/setDefaultTiddlers.tid
@@ -3,4 +3,3 @@ type: None
 tags: excludeLists excludeSearch
 
 Once you have some content then you may choose to determine a tiddler, or set of tiddlers to display each time you load ~TiddlySpace. This is determined by the [[DefaultTiddlers]].
-<html><hr><html>

--- a/src/system-info/spaceIcon.tid
+++ b/src/system-info/spaceIcon.tid
@@ -5,4 +5,3 @@ tags: excludeLists excludeSearch
 A [[SiteIcon|SiteIcon tiddler]]@glossary helps provide some identity to your space.  Ideally it'd be a square and a minimum of 48*48 pixels size.  You can upload your site icon using the uploader below.
 
 <<binaryUploadPublic title:SiteIcon>>
-<html><hr><html>

--- a/src/system-info/spaceTitle.tid
+++ b/src/system-info/spaceTitle.tid
@@ -5,4 +5,3 @@ tags: excludeLists excludeSearch
 You can change the title and subtitle of your space, this will be visible to people visiting your space as well as being what is shown the browser tabs.  The content these are stored in two tiddlers, clicking on the links below will open up these tiddlers which you can edit to make changes.
 * [[SiteTitle]]
 * [[SiteSubtitle]]
-<html><hr><html>


### PR DESCRIPTION
It now lists a few themes and links to the themes space. I'm not sure
whether the exact list is correct, and it can likely be improved, but
this seems like a good starting point.
