### PR TITLE
TiddlySpaceCloneCommand should use chkPrivateMode

### DIFF
--- a/src/plugins/TiddlySpaceCloneCommand.js
+++ b/src/plugins/TiddlySpaceCloneCommand.js
@@ -27,7 +27,8 @@ cmd.cloneTiddler = {
 		var tiddler = store.getTiddler(title);
 		if(tiddler) {
 			fieldsCache[title] = $.extend({}, tiddler.fields);
-			tiddler.fields["server.workspace"] = tiddlyspace.getCurrentWorkspace("private");
+			tiddler.fields["server.workspace"] = tiddlyspace.getCurrentWorkspace(config.options.chkPrivateMode ?
+		"private" : "public");
 			tiddler.fields["server.permissions"] = "read, write, create"; // no delete
 			delete tiddler.fields["server.page.revision"];
 			delete tiddler.fields["server.title"];

--- a/src/plugins/TiddlySpaceCloneCommand.js
+++ b/src/plugins/TiddlySpaceCloneCommand.js
@@ -1,6 +1,6 @@
 /***
 |''Name''|TiddlySpaceCloneCommand|
-|''Version''|0.5.7|
+|''Version''|0.5.8|
 |''Description''|provides a toolbar command for cloning external tiddlers|
 |''Status''|stable|
 |''Source''|http://github.com/TiddlySpace/tiddlyspace/raw/master/src/plugins/TiddlySpaceCloneCommand.js|


### PR DESCRIPTION
Cloning an included tiddler should respect the chkPrivateMode user setting
