### PR TITLE
Fix for #951 remove write when not available

### DIFF
--- a/src/apps/backstage.tid
+++ b/src/apps/backstage.tid
@@ -93,6 +93,9 @@ _cache-max-age: 43200
 				ev.preventDefault();
 			});
 		}
+		if ($(document.body).hasClass('ts-nonmember')) {
+			$('.write').remove();
+		}
 		if(!ts.user.anon) {
 			li = $('<li class="account" />').appendTo("#app-list")[0];
 			siteiconurl = host + '/bags/' + ts.user.name + '_public/tiddlers/SiteIcon';


### PR DESCRIPTION
This fix simply removes write completely if it's unavailable. The user
can't see it or use it anyway so it makes sense to not show it at all.
