### PR TITLE
Fix for issue #954. Grammar for the space stats is now correct.

### DIFF
--- a/src/system-applications/_space.tid
+++ b/src/system-applications/_space.tid
@@ -104,11 +104,16 @@ tags: excludeLists excludeSearch excludeMissing
 					function printFullInfo(numPublicTiddlers) {
 						var totalTiddlers = numPublicTiddlers + numTiddlers;
 						html += ['This space has ', numMembers,
-							' members, <a href="/tiddlers">', totalTiddlers,
+							(numMembers <= 1) ? ' member,' : ' members,',
+							' <a href="/tiddlers">', totalTiddlers,
 							' local tiddlers</a>, <a href="' + url + '">',
-							numTiddlers, ' are private</a> and <a href="',
+							numTiddlers, 
+							(numTiddlers === 0 || numTiddlers > 1) ? ' are' : ' is',
+							' private</a> and <a href="',
 							publicBagUrl, '">',
-							numPublicTiddlers, ' public</a>.'].join("");
+							numPublicTiddlers,
+							(numPublicTiddlers === 0 || numPublicTiddlers > 1) ? ' are' : ' is',
+							 ' public</a>.'].join("");
 						$("#info").html(html);
 					}
 					if(numMembers) {


### PR DESCRIPTION
1 member, 2 members, etc
0 or many tiddlers uses 'are'
1 tiddler uses 'is'
