### PR TITLE
Fix issue #982 add an explicit atom feed link to profile page.

### DIFF
--- a/tiddlywebplugins/templates/tsprofile.html
+++ b/tiddlywebplugins/templates/tsprofile.html
@@ -10,6 +10,9 @@
                 <img src="{{ avatar_path }}" alt="avatar" class="photo" />
             </a>
         </h1>
+        <div class="meta section" id="links">
+            <a href="{{ activity_feed }}">atom feed</a>
+        </div>
 {% endblock %}
 {% block content %}
         <div class="main section" id="profile">


### PR DESCRIPTION
Simply adds an explicit link below the profile picture.
