### PR TITLE
HTML search results use site icons and time ago plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ test:
 tiddlywiki:
 	mkdir src/externals || true
 	mkdir tiddlywebplugins/tiddlyspace/resources || true
-	wget http://tiddlywiki.com/beta/empty.html \
+	wget http://tiddlywiki.github.com/beta/empty.html \
 		-O tiddlywebplugins/tiddlyspace/resources/beta.html
-	wget http://tiddlywiki.com/alpha/empty.html \
+	wget http://tiddlywiki.github.com/alpha/empty.html \
 		-O tiddlywebplugins/tiddlyspace/resources/alpha.html
-	wget http://tiddlywiki.com/alpha/tiddlywiki_externaljs_tiddlyspace.html \
+	wget http://tiddlywiki.github.com/alpha/tiddlywiki_externaljs_tiddlyspace.html \
 		-O tiddlywebplugins/tiddlyspace/resources/external_alpha.html
-	wget http://tiddlywiki.com/alpha/jquery.js \
+	wget http://tiddlywiki.github.com/alpha/jquery.js \
 		-O src/externals/alpha_jquery.js.js
-	wget http://tiddlywiki.com/alpha/jQuery.twStylesheet.js \
+	wget http://tiddlywiki.github.com/alpha/jQuery.twStylesheet.js \
 		-O src/externals/alpha_jQuery.twStylesheet.js.js
-	wget http://tiddlywiki.com/alpha/twcore.js \
+	wget http://tiddlywiki.github.com/alpha/twcore.js \
 		-O src/externals/alpha_twcore.js.js
 
 
@@ -46,6 +46,8 @@ jslib: qunit
 		http://jquery-json.googlecode.com/files/jquery.json-2.3.min.js)
 	$(call wrap_jslib, src/lib/jquery-form.js.js, \
 		https://raw.github.com/malsup/form/master/jquery.form.js)
+	$(call wrap_jslib, src/lib/jquery.timeago.js.js, \
+		http://timeago.yarp.com/jquery.timeago.js)
 
 qunit:
 	mkdir -p src/test/qunit

--- a/src/common.recipe
+++ b/src/common.recipe
@@ -13,6 +13,8 @@ tiddler: lib/chrjs.users.js
 tiddler: lib/chrjs.space.js
 tiddler: lib/chrjs.identities.js
 tiddler: lib/jquery-form.js.js
+tiddler: lib/jquery.timeago.js.js
+tiddler: lib/run-timeago.js.js
 tiddler: icons/close.png.tid
 tiddler: icons/backstage.png.tid
 tiddler: icons/shim.tid

--- a/src/lib/run-timeago.js.js
+++ b/src/lib/run-timeago.js.js
@@ -1,0 +1,28 @@
+/***
+ Apply timeago against class annotated elements
+ matching the format: <el class="timeago" title="timestamp"/>.
+ Requires jquery,timeago - http://timeago.yarp.com/
+ ***/
+//{{{
+$(function () {
+
+    function dateString(date) {
+        return new Date(Date.UTC(
+            parseInt(date.substr(0, 4), 10),
+            parseInt(date.substr(4, 2), 10) - 1,
+            parseInt(date.substr(6, 2), 10),
+            parseInt(date.substr(8, 2), 10),
+            parseInt(date.substr(10, 2), 10),
+            parseInt(date.substr(12, 2) || "0", 10),
+            parseInt(date.substr(14, 3) || "0", 10)
+        )).toISOString();
+    }
+
+    $(".timeago").each(function () {
+        $(this).attr('title', dateString($(this).attr('title')));
+        $(this).timeago();
+    });
+});
+//}}}
+
+

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -275,6 +275,23 @@ table.twtable {
 	}
 }
 
+/**********/
+/* Search */
+/**********/
+/* TODO: move to dedicated stylesheet. */
+.search {
+    list-style-type: none;
+    line-height: 48px;
+}
+
+.search img {
+    width: 48px;
+    height: 48px;
+    vertical-align: middle;
+    padding-right: 5px;
+    padding-bottom: 5px;
+}
+
 /*****************/
 /* Media Queries */
 /*****************/

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -118,7 +118,7 @@ def test_search_no_args():
     response, content = http.request('http://0.0.0.0:8080/search.json?q=_limit:999')
     assert response['status'] == '200'
     allinfo = simplejson.loads(content)
-    assert len(allinfo) == 163
+    assert len(allinfo) == 165
 
     response, content = http.request('http://fnd.0.0.0.0:8080/search.json')
     assert response['status'] == '200'
@@ -128,7 +128,7 @@ def test_search_no_args():
     response, content = http.request('http://fnd.0.0.0.0:8080/search.json?q=_limit:999')
     assert response['status'] == '200'
     fndinfo = simplejson.loads(content)
-    assert len(fndinfo) == 144
+    assert len(fndinfo) == 146
 
     assert len(allinfo) > len(fndinfo)
 
@@ -155,6 +155,8 @@ def test_search_html():
 
     assert '<a class="space" href="http://fnd.0.0.0.0:8080/">' in content
 
+    assert '<img alt="space icon" src="http://fnd.0.0.0.0:8080/SiteIcon"/>' in content
+
     tiddler = store.get(Tiddler('One Two', 'fnd_public'))
     tiddler.modifier = 'cowboy'
     store.put(tiddler)
@@ -163,3 +165,11 @@ def test_search_html():
     assert response['status'] == '200', content
     assert '<a class="modifier" href="http://fnd.0.0.0.0:8080/">' not in content
     assert '<a class="modifier" href="http://cowboy.0.0.0.0:8080/">' in content
+    # tiddlers that do not come from a space should show the default tiddlyspace site icon.
+    tiddler = Tiddler('commoner', 'common')
+    tiddler.text = 'I want to live like common people.'
+    store.put(tiddler)
+
+    response, content = http.request('http://0.0.0.0:8080/search?q=title:commoner')
+    assert response['status'] == '200', content
+    assert '<img alt="space icon" src="http://0.0.0.0:8080/SiteIcon"/>' in content

--- a/tiddlywebplugins/templates/search.html
+++ b/tiddlywebplugins/templates/search.html
@@ -18,13 +18,19 @@
         <div class="main section" id="tiddlers">
             <ul id="tiddlers" class="listing">
             {% for tiddler in tiddlers %}
-                <li>
+                <li class="search">
+                {% if space_bag(tiddler.bag) -%}
+                    <img alt="space icon" src="{{
+                    '%s%s' % (space_uri(environ, tiddler.bag.split('_')[0]), 'SiteIcon')}}"/>
+                {% else -%}
+                    <img alt="space icon" src="{{ '%s/%s' % (original_server_host, 'SiteIcon') }}"/>
+                {%- endif -%}
                 <a class="title"
                     href="{{ tiddler_url(environ, tiddler,
                     container_type, friendly=True) }}">{{
                     tiddler.title|e }}</a>
-                modified <span
-                    class="modified">{{tiddler.modified|format_modified}}</a>
+                modified <span class="modified timeago"
+                   title="{{ tiddler.modified }}">{{ tiddler.modified|format_modified }}</span></a>
                 {% if tiddler.modifier -%}
                 by <a class="modifier" href="{{ space_uri(environ,
                     tiddler.modifier) }}">@{{tiddler.modifier}}</a>
@@ -41,4 +47,9 @@
             {% endfor %}
             </ul>
         </div>
+{% endblock %}
+{% block scripts %}
+<script type="text/javascript" src="/bags/common/tiddlers/jquery.js"></script>
+<script type="text/javascript" src="/bags/common/tiddlers/jquery.timeago.js"></script>
+<script type="text/javascript" src="/bags/common/tiddlers/run-timeago.js"></script>
 {% endblock %}


### PR DESCRIPTION
- Space site icons used as list items.
- When a tiddler does not come from a space, the default site icon is used.
- jquery.timeago plugin included and run against tiddler modified timestamps in search template.
- Makefile updated to pull in jquery.timeago plugin.
- Makefile also uses github.tiddlywiki.com as tiddlywiki.com is returning 404.
- HTML search test assertions updated to reflect more tiddlers included.
