### PR TITLE
JSHint target and simplified PhantomJS installation and usage.

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,9 +1,3 @@
-*.pyc
-
-dev_instance
-
-src/externals
-
 src/lib/chrjs.js
 src/lib/chrjs.users.js
 src/lib/bookmark_bubble.js.js
@@ -13,11 +7,3 @@ src/lib/jquery-json.js.js
 src/lib/jquery.js.js
 src/lib/jquery.timeago.js.js
 src/lib/ts.js.js
-
-src/test/qunit
-src/test/run-qunit.js
-src/test/lib
-
-test_instance
-
-tiddlywebplugins/tiddlyspace/resources

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,4 @@
-.PHONY: test remotes jslib qunit phantomjs jstest pytest dist release deploy pypi dev clean purge
-
-OS := $(shell uname)
-ARCH := $(shell uname -m)
-PHANTOMJS_MAC := phantomjs-1.6.1-macosx-static.zip
-PHANTOMJS_LINUX_32 := phantomjs-1.6.1-linux-i686-dynamic.tar.bz2
-PHANTOMJS_LINUX_64 := phantomjs-1.6.1-linux-x86_64-dynamic.tar.bz2
-ifeq ($(OS), Linux)
-	ifeq ($(ARCH), x86_64)
-		PHANTOMJS_DL := $(PHANTOMJS_LINUX_64)
-	else
-		PHANTOMJS_DL := $(PHANTOMJS_LINUX_32)
-	endif
-endif
-ifeq ($(OS), Darwin)
-	PHANTOMJS_DL := $(PHANTOMJS_MAC)
-endif
+.PHONY: test remotes jslib qunit get_phantomjs get_jshint jshint jstest pytest dist release deploy pypi dev clean purge
 
 wrap_jslib = curl -L -s $(2) | \
 	{ \
@@ -24,7 +8,7 @@ wrap_jslib = curl -L -s $(2) | \
 
 pytest:
 	py.test -x test
-	
+
 test: pytest jstest
 
 tiddlywiki:
@@ -82,15 +66,17 @@ qunit:
 	curl -Lo src/test/run-qunit.js \
 		https://raw.github.com/ariya/phantomjs/1.6/examples/run-qunit.js
 
-phantomjs:
-	wget http://phantomjs.googlecode.com/files/$(PHANTOMJS_DL) \
-	-O phantomjs.tar.bz2
-	tar xjf phantomjs.tar.bz2
-	mv phantomjs-* phantomjs
+get_phantomjs:
+	npm install -g phantomjs
 
 jstest:
-	@cd phantomjs/bin && \
-	./phantomjs ../../src/test/run-qunit.js ../../src/test/index.html
+	phantomjs src/test/run-qunit.js src/test/index.html
+
+get_jshint:
+	npm install -g jshint
+
+jshint:
+	jshint src/**/*.js
 
 dist: clean remotes test
 	python setup.py sdist

--- a/doc/CONTRIBUTING
+++ b/doc/CONTRIBUTING
@@ -9,7 +9,7 @@ also see STYLE guide
 Unit Tests
 ==========
 
-* `make test` runs all tests.  
+* `make test` runs all tests.
 * From scratch you should run `make remotes phantomjs test`
 * Python: test directory, using py.test (http://pytest.org)
 * JavaScript: src/test directory, using QUnit (http://docs.jquery.com/QUnit)
@@ -21,6 +21,7 @@ Development Instance
 * install dependencies
 ** components listed in setup.py's install_requires
 ** httplib2, PyYAML (required for testing)
+** node (required for JavaScript testing and linting)
 
 * Set up mysql on your machine. See MYSQL.
 


### PR DESCRIPTION
- Make targets to install JSHint and PhantomJS via node.
- Make target to run JSHint over all JS files apart from those specified in .jshintignore.
- Note added to CONTRIBUTING stating that node is required for development.
- .gitignore file includes all files that come from external sources.
- .jshintignore file as above.
