### PR TITLE
Update HTTPExceptor imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'tiddlywebplugins.templates',
         'tiddlywebplugins.csrf',
         'tiddlywebplugins.whoosher',
+        'tiddlywebplugins.markdown',
         'selector<0.9.0',
         'httpexceptor>=1.1.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     scripts = ['tiddlyspace'],
     install_requires = [
         'setuptools',
-        'tiddlyweb>=1.2.51',
+        'tiddlyweb>=1.3.0',
         'tiddlywebwiki>=0.57.0',
         'tiddlywebplugins.status>=0.6',
         'tiddlywebplugins.utils>=1.0',
@@ -51,8 +51,7 @@ setup(
         'tiddlywebplugins.csrf',
         'tiddlywebplugins.whoosher',
         'tiddlywebplugins.markdown',
-        'selector<0.9.0',
-        'httpexceptor>=1.1.0'
+        'selector<0.9.0'
     ],
     include_package_data = True,
     zip_safe = False,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(
         'tiddlywebplugins.templates',
         'tiddlywebplugins.csrf',
         'tiddlywebplugins.whoosher',
-        'selector<0.9.0'
+        'selector<0.9.0',
+        'httpexceptor>=1.1.0'
     ],
     include_package_data = True,
     zip_safe = False,

--- a/tiddlywebplugins/tiddlyspace/controlview.py
+++ b/tiddlywebplugins/tiddlyspace/controlview.py
@@ -31,7 +31,7 @@ from tiddlyweb.model.bag import Bag
 from tiddlyweb.model.recipe import Recipe
 from tiddlyweb.serializer import Serializer
 from tiddlyweb.store import NoRecipeError
-from tiddlyweb.web.http import HTTP404, HTTP400
+from httpexceptor import HTTP404, HTTP400
 from tiddlyweb.web.listentities import list_entities
 from tiddlyweb.web.util import get_serialize_type
 

--- a/tiddlywebplugins/tiddlyspace/handler.py
+++ b/tiddlywebplugins/tiddlyspace/handler.py
@@ -17,7 +17,7 @@ from tiddlyweb.store import NoBagError
 from tiddlyweb import control
 from tiddlyweb.web.handler.recipe import get_tiddlers
 from tiddlyweb.web.handler.tiddler import get as get_tiddler
-from tiddlyweb.web.http import HTTP403
+from httpexceptor import HTTP403
 from tiddlyweb.web.util import get_serialize_type
 
 from tiddlywebplugins.utils import require_any_user

--- a/tiddlywebplugins/tiddlyspace/profiles.py
+++ b/tiddlywebplugins/tiddlyspace/profiles.py
@@ -12,7 +12,7 @@ from tiddlyweb.store import StoreError, NoUserError
 from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.model.user import User
 from tiddlyweb.web.handler.search import get as search
-from tiddlyweb.web.http import HTTP404, HTTP400, HTTP415
+from httpexceptor import HTTP404, HTTP400, HTTP415
 from tiddlyweb.web.util import (server_host_url, encode_name,
         get_serialize_type, tiddler_url)
 from tiddlywebplugins.tiddlyspace.spaces import space_uri

--- a/tiddlywebplugins/tiddlyspace/safemode.py
+++ b/tiddlywebplugins/tiddlyspace/safemode.py
@@ -10,7 +10,7 @@ from tiddlyweb.model.collections import Tiddlers
 from tiddlyweb.model.recipe import Recipe
 from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.store import NoBagError, NoRecipeError, NoTiddlerError
-from tiddlyweb.web.http import HTTP403, HTTP404
+from httpexceptor import HTTP403, HTTP404
 from tiddlyweb.web.sendtiddlers import send_tiddlers
 from tiddlyweb.web.util import get_serialize_type
 

--- a/tiddlywebplugins/tiddlyspace/spaces.py
+++ b/tiddlywebplugins/tiddlyspace/spaces.py
@@ -11,7 +11,7 @@ from tiddlyweb.model.recipe import Recipe
 from tiddlyweb.model.user import User
 from tiddlyweb.model.policy import Policy
 from tiddlyweb.store import NoRecipeError, NoBagError, NoUserError
-from tiddlyweb.web.http import HTTP403, HTTP404, HTTP409
+from httpexceptor import HTTP403, HTTP404, HTTP409
 
 from tiddlywebplugins.utils import require_any_user
 

--- a/tiddlywebplugins/tiddlyspace/web.py
+++ b/tiddlywebplugins/tiddlyspace/web.py
@@ -6,7 +6,7 @@ from tiddlyweb.model.policy import PermissionsError
 from tiddlyweb.model.recipe import Recipe
 from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.store import StoreError
-from tiddlyweb.web.http import HTTP404
+from httpexceptor import HTTP404
 
 from tiddlywebplugins.tiddlyspace.space import Space
 


### PR DESCRIPTION
Now that the HTTPExceptor code has been extracted into an independent library there are imports that are out of date and break (I found this when running the cacher when performing a fresh development install).
