### PR TITLE
Fallback to msfilter property if background-size is not supported.

### DIFF
--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -54,8 +54,8 @@ function hasBgSizing() {
 var backgroundSizeSupported = hasBgSizing();
 
 // ms filters as fix for not supporting background-size property
-var msfilter_in = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')",
-	msfilter_out = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')";
+var msfilter_in = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')",
+	msfilter_out = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')";
 
 var stylesheet = ["iframe {",
 "	height: 180px;",

--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -54,8 +54,8 @@ function hasBgSizing() {
 var backgroundSizeSupported = hasBgSizing();
 
 // ms filters as fix for not supporting background-size property
-var msfilter_in = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://osmowhat.tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')",
-	msfilter_out = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://osmowhat.tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')";
+var msfilter_in = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')",
+	msfilter_out = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')";
 
 var stylesheet = ["iframe {",
 "	height: 180px;",

--- a/src/apps/backstage.js.js
+++ b/src/apps/backstage.js.js
@@ -38,6 +38,25 @@ var twStylesheet = function(css, options) {
 	}
 };
 
+// detect background-size support
+// in <IE9 need to fallback to msfilter property
+function hasBgSizing() {
+	var supported,
+		elem = document.createElement('div');
+
+	document.body.appendChild(elem);
+	elem.style.cssText = "background-size: cover;";
+	supported = (elem.style.backgroundSize === undefined || elem.style.backgroundSize === null) ? false : true;
+	// clean up
+	elem.parentNode.removeChild(elem);
+	return supported;
+}
+var backgroundSizeSupported = hasBgSizing();
+
+// ms filters as fix for not supporting background-size property
+var msfilter_in = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://osmowhat.tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')",
+	msfilter_out = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src='http://osmowhat.tiddlyspace.com/bags/tiddlyspace/tiddlers/privateAndPublicIcon', sizingMethod='scale')";
+
 var stylesheet = ["iframe {",
 "	height: 180px;",
 "	z-index: 1000;",
@@ -150,9 +169,17 @@ var loadEvent = function() {
 
         // Quite a hack. GUEST does not have a csrf token.
         if (/csrf_token=\d+:\w+:\w+/.test(document.cookie)) {
-            link.style.backgroundImage = 'url(/bags/tiddlyspace/tiddlers/privateAndPublicIcon)';
+			if( backgroundSizeSupported ) {
+				link.style.backgroundImage = 'url(/bags/tiddlyspace/tiddlers/privateAndPublicIcon)';
+			} else {
+				link.style.filter = msfilter_in;
+			}
         } else {
-            link.style.backgroundImage = 'url(/bags/tiddlyspace/tiddlers/publicIcon)';
+			if( backgroundSizeSupported ) {
+				link.style.backgroundImage = 'url(/bags/tiddlyspace/tiddlers/publicIcon)';
+			} else {
+				link.style.filter = msfilter_out;
+			}
 			stylesheet = stylesheet.replace('height: 180px;', 'height: 156px;');
         }
 


### PR DESCRIPTION
In IE the roundel is much larger than the desired 24x24px, turned out it was because we used the CSS3 property background-size to scale an image, which IE ignores. This fixes it.

Function to test support was required. IE6-8 supports background-size: auto; but not other options such as cover so had to test for ability to handle that.
